### PR TITLE
AddFetchTimeout discards curl options if 'timeout' is not defined.

### DIFF
--- a/src/pprof
+++ b/src/pprof
@@ -3410,7 +3410,7 @@ sub ResolveRedirectionForCurl {
 # Add a timeout flat to URL_FETCHER.  Returns a new list.
 sub AddFetchTimeout {
   my $timeout = shift;
-  my @fetcher = shift;
+  my @fetcher = @_;
   if (defined($timeout)) {
     if (join(" ", @fetcher) =~ m/\bcurl -s/) {
       push(@fetcher, "--max-time", sprintf("%d", $timeout));


### PR DESCRIPTION
Editing the options passed to curl via 'my @URL_FETCHER = ("curl", "-s");' (in particular to add a -k to ignore self signed certs) fails for some invocations of curl. In FetchDynamicProfile, 'my @fetcher = AddFetchTimeout($fetch_timeout, @URL_FETCHER);' ends up being just 'curl' if timeout is not defined.

This happens because AddFetchTimeout doesn't retrieve all the arguments from the caller.