### PR TITLE
Ensure ThreadCache objects are CACHELINE_ALIGNED.

### DIFF
--- a/src/base/basictypes.h
+++ b/src/base/basictypes.h
@@ -364,6 +364,12 @@ class AssignAttributeStartEnd {
 # define CACHELINE_ALIGNED
 #endif  // defined(HAVE___ATTRIBUTE__) && (__i386__ || __x86_64__)
 
+// Structure for discovering alignment
+union MemoryAligner {
+  void*  p;
+  double d;
+  size_t s;
+} CACHELINE_ALIGNED;
 
 // The following enum should be used only as a constructor argument to indicate
 // that the variable has static storage class, and that the constructor should

--- a/src/common.cc
+++ b/src/common.cc
@@ -221,9 +221,9 @@ void SizeMap::Init() {
 static uint64_t metadata_system_bytes_ = 0;
 static const size_t kMetadataAllocChunkSize = 8*1024*1024;
 static const size_t kMetadataBigAllocThreshold = kMetadataAllocChunkSize / 8;
-// usually malloc uses larger alignments, but because metadata cannot
-// have and fancy simd types, aligning on pointer size seems fine
-static const size_t kMetadataAllignment = sizeof(void *);
+// As ThreadCache objects are allocated with MetaDataAlloc, and also
+// CACHELINE_ALIGNED, we must use the same alignment as TCMalloc_SystemAlloc.
+static const size_t kMetadataAllignment = sizeof(MemoryAligner);
 
 static char *metadata_chunk_alloc_;
 static size_t metadata_chunk_avail_;

--- a/src/system-alloc.cc
+++ b/src/system-alloc.cc
@@ -106,13 +106,6 @@ template <> bool CheckAddressBits<8 * sizeof(void*)>(uintptr_t ptr) {
 COMPILE_ASSERT(kAddressBits <= 8 * sizeof(void*),
                address_bits_larger_than_pointer_size);
 
-// Structure for discovering alignment
-union MemoryAligner {
-  void*  p;
-  double d;
-  size_t s;
-} CACHELINE_ALIGNED;
-
 static SpinLock spinlock(SpinLock::LINKER_INITIALIZED);
 
 #if defined(HAVE_MMAP) || defined(MADV_FREE)


### PR DESCRIPTION
The ThreadCache class comments that it is 'critical for performance' that it's correctly aligned, which it enforces with the CACHELINE_ALIGNED attribute.

ThreadCache objects are allocated by ThreadCache::NewHeap. This uses threadcache_allocator to obtain memory, where threadcache_allocator is a PageHeapAllocator.

PageHeapAllocator::New uses MetaDataAlloc to allocate memory, which returns blocks from space allocated with TCMalloc_SystemAlloc.

TCMalloc_SystemAlloc uses a MemoryAligner union to ensure alignment is always CACHELINE_ALIGNED in size.

MetaDataAlloc uses a void* for alignment so it may return pointers with a smaller alignment.

This causes ThreadCache objects to be void*-aligned rather than CACHELINE_ALIGNED.

This was detected by Clang's Undefined Behavior Sanitizer on x86_64.

This breaks in ThreadCache::NewHeap because the pointer assigned to the ThreadCache instance does not match the expected CACHELINE_ALIGNED alignment of the ThreadCache class.