### PR TITLE
Basic implementation of C++14 sized deallocation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,9 @@ endif GCC
 if HAVE_W_NO_UNUSED_RESULT
 AM_CXXFLAGS += -Wno-unused-result
 endif HAVE_W_NO_UNUSED_RESULT
+if HAVE_SIZED_DEALLOCATION
+AM_CXXFLAGS += -fsized-deallocation
+endif HAVE_SIZED_DEALLOCATION
 
 # The -no-undefined flag allows libtool to generate shared libraries for
 # Cygwin and MinGW.  LIBSTDCXX_LA_LINKER_FLAG is used to fix a Solaris bug.

--- a/configure.ac
+++ b/configure.ac
@@ -323,16 +323,28 @@ AC_CACHE_CHECK([if the compiler supports -Wno-unused-result],
 AM_CONDITIONAL(HAVE_W_NO_UNUSED_RESULT,
 	       test "$perftools_cv_w_no_unused_result" = yes)
 
-AC_CACHE_CHECK([if C++ compiler supports -fsized-deallocation],
-               perftools_cv_sized_deallocation_result,
-               [AC_LANG_PUSH(C++)
-                OLD_CXXFLAGS="$CXXFLAGS"
-                CXXFLAGS="$CXXFLAGS -fsized-deallocation"
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,)],
-                                  perftools_cv_sized_deallocation_result=yes,
-                                  perftools_cv_sized_deallocation_result=no)
-                CXXFLAGS="$OLD_CXXFLAGS"
-                AC_LANG_POP(C++)])
+AC_ARG_ENABLE([sized-delete],
+              [AS_HELP_STRING([--enable-sized-delete],
+                              [build sized delete operator])],
+              [enable_sized_delete="$enableval"],
+              [enable_sized_delete="no"])
+AS_IF([test "x$enable_sized_delete" = xyes],
+        [AC_DEFINE([ENABLE_SIZED_DELETE], 1, [Build sized deletion operators])
+         AC_MSG_NOTICE([Will build sized deallocation operators])],
+      [AC_MSG_NOTICE([Will not build sized deallocation operators])])
+
+AS_IF([test "x$enable_sized_delete" = xyes],
+      [AC_CACHE_CHECK([if C++ compiler supports -fsized-deallocation],
+                      perftools_cv_sized_deallocation_result,
+                      [AC_LANG_PUSH(C++)
+                       OLD_CXXFLAGS="$CXXFLAGS"
+                       CXXFLAGS="$CXXFLAGS -fsized-deallocation"
+                       AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,)],
+                                         perftools_cv_sized_deallocation_result="$enable_sized_delete",
+                                         perftools_cv_sized_deallocation_result=no)
+                       CXXFLAGS="$OLD_CXXFLAGS"
+                       AC_LANG_POP(C++)])])
+
 AM_CONDITIONAL(HAVE_SIZED_DEALLOCATION,
                test "$perftools_cv_sized_deallocation_result" = yes)
 

--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,19 @@ AC_CACHE_CHECK([if the compiler supports -Wno-unused-result],
 AM_CONDITIONAL(HAVE_W_NO_UNUSED_RESULT,
 	       test "$perftools_cv_w_no_unused_result" = yes)
 
+AC_CACHE_CHECK([if C++ compiler supports -fsized-deallocation],
+               perftools_cv_sized_deallocation_result,
+               [AC_LANG_PUSH(C++)
+                OLD_CXXFLAGS="$CXXFLAGS"
+                CXXFLAGS="$CXXFLAGS -fsized-deallocation"
+                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,)],
+                                  perftools_cv_sized_deallocation_result=yes,
+                                  perftools_cv_sized_deallocation_result=no)
+                CXXFLAGS="$OLD_CXXFLAGS"
+                AC_LANG_POP(C++)])
+AM_CONDITIONAL(HAVE_SIZED_DEALLOCATION,
+               test "$perftools_cv_sized_deallocation_result" = yes)
+
 # Defines PRIuS
 AC_COMPILER_CHARACTERISTICS
 

--- a/configure.ac
+++ b/configure.ac
@@ -306,11 +306,16 @@ AM_CONDITIONAL(I386, test "$is_i386" = yes)
 AC_CACHE_CHECK([if the compiler supports -Wno-unused-result],
                perftools_cv_w_no_unused_result,
 	       [OLD_CFLAGS="$CFLAGS"
-	        CFLAGS="$CFLAGS -Wno-error -Wno-unused-result"
+	        CFLAGS="$CFLAGS -Wno-error -Wunused-result"
 		# gcc doesn't warn about unknown flags unless it's
 		# also warning for some other purpose, hence the
 		# divide-by-0.  (We use -Wno-error to make sure the
 		# divide-by-0 doesn't cause this test to fail!)
+                #
+                # Also gcc is giving only warning for unknown flags of
+                # -Wno-XXX form. So in order to detect support we're
+                # using -Wunused-result which will cause gcc to give
+                # error which we can detect.
 	        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(, return 1/0)],
 	                          perftools_cv_w_no_unused_result=yes,
                                   perftools_cv_w_no_unused_result=no)

--- a/src/base/basictypes.h
+++ b/src/base/basictypes.h
@@ -83,7 +83,7 @@ const  int64 kint64max =  ( ((( int64) kint32max) << 32) | kuint32max );
 const  int8  kint8min   = (   (  int8) 0x80);
 const  int16 kint16min  = (   ( int16) 0x8000);
 const  int32 kint32min  = (   ( int32) 0x80000000);
-const  int64 kint64min =  ( ((( int64) kint32min) << 32) | 0 );
+const  int64 kint64min =  ( (((uint64) kint32min) << 32) | 0 );
 
 // Define the "portable" printf and scanf macros, if they're not
 // already there (via the inttypes.h we #included above, hopefully).

--- a/src/gperftools/tcmalloc.h.in
+++ b/src/gperftools/tcmalloc.h.in
@@ -91,6 +91,7 @@ extern "C" {
   PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) __THROW;
   PERFTOOLS_DLL_DECL void tc_free(void* ptr) __THROW;
+  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) __THROW;

--- a/src/gperftools/tcmalloc.h.in
+++ b/src/gperftools/tcmalloc.h.in
@@ -122,12 +122,14 @@ extern "C" {
   PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size,
                                           const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void tc_delete(void* p) __THROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) throw();
   PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p,
                                             const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void* tc_newarray(size_t size);
   PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size,
                                                const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void tc_deletearray(void* p) __THROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) throw();
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
                                                  const std::nothrow_t&) __THROW;
 }

--- a/src/libc_override_gcc_and_weak.h
+++ b/src/libc_override_gcc_and_weak.h
@@ -71,6 +71,13 @@ void operator delete(void* p, const std::nothrow_t& nt) __THROW
 void operator delete[](void* p, const std::nothrow_t& nt) __THROW
     ALIAS(tc_deletearray_nothrow);
 
+#ifdef ENABLE_SIZED_DELETE
+void operator delete(void *p, size_t size) throw()
+    ALIAS(tc_delete_sized);
+void operator delete[](void *p, size_t size) throw()
+    ALIAS(tc_deletearray_sized);
+#endif
+
 extern "C" {
   void* malloc(size_t size) __THROW               ALIAS(tc_malloc);
   void free(void* ptr) __THROW                    ALIAS(tc_free);

--- a/src/libc_override_redefine.h
+++ b/src/libc_override_redefine.h
@@ -66,6 +66,12 @@ void operator delete(void* ptr, const std::nothrow_t& nt) __THROW {
 void operator delete[](void* ptr, const std::nothrow_t& nt) __THROW {
   return tc_deletearray_nothrow(ptr, nt);
 }
+
+#ifdef ENABLE_SIZED_DELETE
+void operator delete(void* p, size_t s) __THROW  { tc_delete_sized(p, s);     }
+void operator delete[](void* p, size_t s) __THROW{ tc_deletearray_sized(p);   }
+#endif
+
 extern "C" {
   void* malloc(size_t s) __THROW                 { return tc_malloc(s);       }
   void  free(void* p) __THROW                    { tc_free(p);                }

--- a/src/malloc_hook-inl.h
+++ b/src/malloc_hook-inl.h
@@ -44,6 +44,8 @@
 #include "base/basictypes.h"
 #include <gperftools/malloc_hook.h>
 
+#include "common.h" // for UNLIKELY
+
 namespace base { namespace internal {
 
 // Capacity of 8 means that HookList is 9 words.
@@ -121,7 +123,7 @@ inline MallocHook::NewHook MallocHook::GetNewHook() {
 }
 
 inline void MallocHook::InvokeNewHook(const void* p, size_t s) {
-  if (!base::internal::new_hooks_.empty()) {
+  if (UNLIKELY(!base::internal::new_hooks_.empty())) {
     InvokeNewHookSlow(p, s);
   }
 }
@@ -132,7 +134,7 @@ inline MallocHook::DeleteHook MallocHook::GetDeleteHook() {
 }
 
 inline void MallocHook::InvokeDeleteHook(const void* p) {
-  if (!base::internal::delete_hooks_.empty()) {
+  if (UNLIKELY(!base::internal::delete_hooks_.empty())) {
     InvokeDeleteHookSlow(p);
   }
 }

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -1595,6 +1595,24 @@ extern "C" PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) __THROW
   do_free_with_callback(ptr, &InvalidFree, true, size);
 }
 
+#if defined(__GNUC__) && !defined(WIN32)
+
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void *p, size_t size) throw()
+  __attribute__((alias("tc_free_sized")));
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void *p, size_t size) throw()
+  __attribute__((alias("tc_free_sized")));
+
+#else
+
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void *p, size_t size) throw() {
+  tc_free_sized(p, size);
+}
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void *p, size_t size) throw() {
+  tc_free_sized(p, size);
+}
+
+#endif
+
 extern "C" PERFTOOLS_DLL_DECL void* tc_calloc(size_t n,
                                               size_t elem_size) __THROW {
   void* result = do_calloc(n, elem_size);

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -1302,11 +1302,10 @@ ALWAYS_INLINE void do_free_helper(void* ptr,
 ALWAYS_INLINE void do_free_with_callback(void* ptr,
                                          void (*invalid_free_fn)(void*)) {
   ThreadCache* heap = NULL;
-  if (LIKELY(ThreadCache::IsFastPathAllowed())) {
-    heap = ThreadCache::GetCacheWhichMustBePresent();
+  heap = ThreadCache::GetCacheIfPresent();
+  if (LIKELY(heap)) {
     do_free_helper(ptr, invalid_free_fn, heap, true);
   } else {
-    heap = ThreadCache::GetCacheIfPresent();
     do_free_helper(ptr, invalid_free_fn, heap, false);
   }
 }

--- a/src/thread_cache.h
+++ b/src/thread_cache.h
@@ -417,7 +417,9 @@ inline ThreadCache* ThreadCache::GetCache() {
 // because we may be in the thread destruction code and may have
 // already cleaned up the cache for this thread.
 inline ThreadCache* ThreadCache::GetCacheIfPresent() {
+#ifndef HAVE_TLS
   if (!tsd_inited_) return NULL;
+#endif
   return GetThreadHeap();
 }
 

--- a/src/windows/gperftools/tcmalloc.h
+++ b/src/windows/gperftools/tcmalloc.h
@@ -81,6 +81,7 @@ extern "C" {
   PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) __THROW;
   PERFTOOLS_DLL_DECL void tc_free(void* ptr) __THROW;
+  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) __THROW;

--- a/src/windows/gperftools/tcmalloc.h
+++ b/src/windows/gperftools/tcmalloc.h
@@ -112,12 +112,14 @@ extern "C" {
   PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size,
                                           const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void tc_delete(void* p) __THROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) throw();
   PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p,
                                             const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void* tc_newarray(size_t size);
   PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size,
                                                const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void tc_deletearray(void* p) __THROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) throw();
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
                                                  const std::nothrow_t&) __THROW;
 }

--- a/src/windows/gperftools/tcmalloc.h.in
+++ b/src/windows/gperftools/tcmalloc.h.in
@@ -81,6 +81,7 @@ extern "C" {
   PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) __THROW;
   PERFTOOLS_DLL_DECL void tc_free(void* ptr) __THROW;
+  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) __THROW;
   PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) __THROW;

--- a/src/windows/gperftools/tcmalloc.h.in
+++ b/src/windows/gperftools/tcmalloc.h.in
@@ -112,12 +112,14 @@ extern "C" {
   PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size,
                                           const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void tc_delete(void* p) __THROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) throw();
   PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p,
                                             const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void* tc_newarray(size_t size);
   PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size,
                                                const std::nothrow_t&) __THROW;
   PERFTOOLS_DLL_DECL void tc_deletearray(void* p) __THROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) throw();
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
                                                  const std::nothrow_t&) __THROW;
 }

--- a/src/windows/patch_functions.cc
+++ b/src/windows/patch_functions.cc
@@ -814,7 +814,7 @@ void LibcInfoWithPatchFunctions<T>::Perftools_free(void* ptr) __THROW {
   // allocated by tcmalloc.  Note it calls the origstub_free from
   // *this* templatized instance of LibcInfo.  See "template
   // trickiness" above.
-  do_free_with_callback(ptr, (void (*)(void*))origstub_fn_[kFree]);
+  do_free_with_callback(ptr, (void (*)(void*))origstub_fn_[kFree], false, 0);
 }
 
 template<int T>
@@ -828,7 +828,7 @@ void* LibcInfoWithPatchFunctions<T>::Perftools_realloc(
   if (new_size == 0) {
     MallocHook::InvokeDeleteHook(old_ptr);
     do_free_with_callback(old_ptr,
-                          (void (*)(void*))origstub_fn_[kFree]);
+                          (void (*)(void*))origstub_fn_[kFree], false, 0);
     return NULL;
   }
   return do_realloc_with_callback(
@@ -862,13 +862,13 @@ void* LibcInfoWithPatchFunctions<T>::Perftools_newarray(size_t size) {
 template<int T>
 void LibcInfoWithPatchFunctions<T>::Perftools_delete(void *p) {
   MallocHook::InvokeDeleteHook(p);
-  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree]);
+  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree], false, 0);
 }
 
 template<int T>
 void LibcInfoWithPatchFunctions<T>::Perftools_deletearray(void *p) {
   MallocHook::InvokeDeleteHook(p);
-  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree]);
+  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree], false, 0);
 }
 
 template<int T>
@@ -891,14 +891,14 @@ template<int T>
 void LibcInfoWithPatchFunctions<T>::Perftools_delete_nothrow(
     void *p, const std::nothrow_t&) __THROW {
   MallocHook::InvokeDeleteHook(p);
-  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree]);
+  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree], false, 0);
 }
 
 template<int T>
 void LibcInfoWithPatchFunctions<T>::Perftools_deletearray_nothrow(
     void *p, const std::nothrow_t&) __THROW {
   MallocHook::InvokeDeleteHook(p);
-  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree]);
+  do_free_with_callback(p, (void (*)(void*))origstub_fn_[kFree], false, 0);
 }
 
 


### PR DESCRIPTION
Hi. This is few commits that end with implementation of sized delete operator. When enabled and supported by compiler (i.e. gcc 5 with -std=c++14) it speeds up deletions fast-path significantly.