### PR TITLE
Fixups for MIPS and callgrind format

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -1582,8 +1582,8 @@ struct kernel_stat {
                               ".set reorder\n"                                \
                               : "=&r"(__v0), "+r" (__r7)                      \
                               : "i" (__NR_##name), "r"(__r4), "r"(__r5),      \
-                                "r"(__r6), "r" ((unsigned long)arg5),         \
-                                "r" ((unsigned long)arg6)                     \
+                                "r"(__r6), "m" ((unsigned long)arg5),         \
+                                "m" ((unsigned long)arg6)                     \
                               : MIPS_SYSCALL_CLOBBERS);                       \
         LSS_RETURN(type, __v0, __r7);                                         \
       }

--- a/src/pprof
+++ b/src/pprof
@@ -1302,7 +1302,7 @@ sub PrintCallgrind {
     $filename = "&STDOUT";
   }
   open(CG, ">$filename");
-  printf CG ("events: Hits\n\n");
+  print CG ("events: Hits\n\n");
   foreach my $call ( map { $_->[0] }
                      sort { $a->[1] cmp $b ->[1] ||
                             $a->[2] <=> $b->[2] }
@@ -1318,14 +1318,14 @@ sub PrintCallgrind {
     # TODO(csilvers): for better compression, collect all the
     # caller/callee_files and functions first, before printing
     # anything, and only compress those referenced more than once.
-    printf CG CompressedCGName("fl", $caller_file, \%filename_to_index_map);
-    printf CG CompressedCGName("fn", $caller_function, \%fnname_to_index_map);
+    print CG CompressedCGName("fl", $caller_file, \%filename_to_index_map);
+    print CG CompressedCGName("fn", $caller_function, \%fnname_to_index_map);
     if (defined $6) {
-      printf CG CompressedCGName("cfl", $callee_file, \%filename_to_index_map);
-      printf CG CompressedCGName("cfn", $callee_function, \%fnname_to_index_map);
-      printf CG ("calls=$count $callee_line\n");
+      print CG CompressedCGName("cfl", $callee_file, \%filename_to_index_map);
+      print CG CompressedCGName("cfn", $callee_function, \%fnname_to_index_map);
+      print CG ("calls=$count $callee_line\n");
     }
-    printf CG ("$caller_line $count\n\n");
+    print CG ("$caller_line $count\n\n");
   }
 }
 


### PR DESCRIPTION
Fixed typo in passing arguments to _syscall6 - it is correctly stated in comment that old MIPS ABI use only 4 registers for argument passing, but the code was trying to pass arg5 and arg6 as registers too.

Also, fixed printf misuse in pprof - the printed string is passed as format. It can cause troubles if string contains "%".