### PR TITLE
avoid double patching when EnumProcessModules fail

### DIFF
--- a/src/windows/patch_functions.cc
+++ b/src/windows/patch_functions.cc
@@ -532,7 +532,7 @@ bool LibcInfo::PopulateWindowsFn(const ModuleEntryCopy& module_entry) {
   for (int i = 0; i < kNumFunctions; i++) {
     if (windows_fn_[i]){
       found_non_null = true;
-	  break;
+      break;
 	}
   }
   if (!found_non_null)
@@ -769,19 +769,18 @@ bool PatchAllModules() {
       }
     }
 
-	//qq325895369:on windows os,the for loop above has already pathched all runtime lib, 
-	//delete following code fragment to avoid double patching,otherwise,
-	//memory functions of tcmalloc self will alse be patched,then lead to dead loop!
-#ifndef WIN32 
-    // Now that we've dealt with the modules (dlls), update the main
-    // executable.  We do this last because PatchMainExecutableLocked
-    // wants to look at how other modules were patched.
+    //qq325895369:on windows os,the for loop above has already pathched all runtime lib, 
+    //delete following code fragment to avoid double patching,otherwise,
+    //memory functions of tcmalloc self will alse be patched,then lead to dead loop!
 
-    if (!main_executable.patched()) {
-      PatchMainExecutableLocked();
-      made_changes = true;
-    }
-#endif
+    //// Now that we've dealt with the modules (dlls), update the main
+    //// executable.  We do this last because PatchMainExecutableLocked
+    //// wants to look at how other modules were patched.
+
+    //if (!main_executable.patched()) {
+    //  PatchMainExecutableLocked();
+    //  made_changes = true;
+    //}
   }
   // TODO(csilvers): for this to be reliable, we need to also take
   // into account if we *would* have patched any modules had they not


### PR DESCRIPTION
when i use tcmalloc,I found a fatal bug in function PatchAllModules,in my own project,link libtcmalloc,encountered a  dead loop problem, so I generated a full dmp file,after my analyzing,then i located here:
once EnumProcessModules fail,when next  time to execute PatchAllModules,if this api call successfully,will lead to double patching,then lead to dead loop finally！（perftools_free<1> jmp to perftools_free<0>,but perftools_free<0> jmp back to perftools_free<1>）

this bug often appears!!!   and you can reappear it by making the EnumProcessModules call fail manually
if not,you can get the dmp file here: http://pan.baidu.com/s/1kTAhEjd

sorry,my english is not good,can you get it?
