### PR TITLE
Add generic.total_physical_bytes property to Mallocextension

### DIFF
--- a/src/gperftools/malloc_extension.h
+++ b/src/gperftools/malloc_extension.h
@@ -160,6 +160,14 @@ class PERFTOOLS_DLL_DECL MallocExtension {
   //            freed memory regions
   //      This property is not writable.
   //
+  //  "generic.total_physical_bytes"
+  //      Estimate of total bytes in physical memory usage by the
+  //      allocator ==
+  //            current_allocated_bytes +
+  //            fragmentation +
+  //            metadata
+  //      This property is not writable.
+  //
   // tcmalloc
   // --------
   // "tcmalloc.max_total_thread_cache_bytes"

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -656,6 +656,16 @@ class TCMallocImplementation : public MallocExtension {
       return true;
     }
 
+    if (strcmp(name, "generic.total_physical_bytes") == 0) {
+      TCMallocStats stats;
+      ExtractStats(&stats, NULL, NULL, NULL);
+      *value = stats.pageheap.system_bytes
+               + stats.metadata_bytes
+               - stats.pageheap.unmapped_bytes
+               - stats.metadata_unmapped_bytes
+      return true;
+    }
+
     if (strcmp(name, "tcmalloc.slack_bytes") == 0) {
       // Kept for backwards compatibility.  Now defined externally as:
       //    pageheap_free_bytes + pageheap_unmapped_bytes.


### PR DESCRIPTION
The actual physical memory usage of tcmalloc cannot be obtained by
GetNumericProperty. This accounts for the current_allocated_bytes,
fragmentation and malloc metadata, and excludes the unmapped memory
regions. This helps the user to understand how much memory is actually
being used for the allocations that were made.