### PR TITLE
fix compilation error in spinlock

### DIFF
--- a/src/base/spinlock.cc
+++ b/src/base/spinlock.cc
@@ -66,7 +66,7 @@ static SpinLock_InitHelper init_helper;
 
 inline void SpinlockPause(void) {
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
-  __builtin_ia32_pause();
+  __asm__ __volatile__("rep; nop" : : );
 #endif
 }
 


### PR DESCRIPTION
Fix compilation error with `__builtin_ia32_pause()`  in gcc-3.4.5