### PR TITLE
support use of configure --docdir argument

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,7 +136,6 @@ googleinclude_HEADERS =				\
    src/google/stacktrace.h			\
    src/google/tcmalloc.h
 
-docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
 # This is for HTML and other documentation you want to install.
 # Add your documentation files (in doc/) in addition to these
 # top-level boilerplate files.  Also add a TODO file if you have one.

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,12 @@ AC_SUBST(TC_VERSION_MINOR)
 AC_SUBST(TC_VERSION_PATCH)
 AC_SUBST(PACKAGE_STRING)
 
+# docdir not defined by autoconf < 2.59c
+if test "$docdir" = ""; then
+   docdir='${datadir}/doc/${PACKAGE}-${VERSION}'
+fi
+AC_SUBST(docdir)
+
 # The user can choose not to compile in the heap-profiler, the
 # heap-checker, or the cpu-profiler.  There's also the possibility
 # for a 'fully minimal' compile, which leaves out the stacktrace


### PR DESCRIPTION
Value of docdir was being overridden in Makefile.

Retain compatibility with old Autoconf versions that do not provide
docdir.