### PR TITLE
Mark aliases "used" to prevent them being deleted during link-time optimization

### DIFF
--- a/src/libc_override_gcc_and_weak.h
+++ b/src/libc_override_gcc_and_weak.h
@@ -55,7 +55,7 @@
 # error libc_override_gcc_and_weak.h is for gcc distributions only.
 #endif
 
-#define ALIAS(tc_fn)   __attribute__ ((alias (#tc_fn)))
+#define ALIAS(tc_fn)   __attribute__ ((alias (#tc_fn), used))
 
 void* operator new(size_t size) throw (std::bad_alloc)
     ALIAS(tc_new);


### PR DESCRIPTION
Make sure aliases are not removed by link-time optimization [LTO] when LTO can prove that they aren't used by the program, as the alias might still be needed to override the corresponding symbol in shared libraries (or in inline assembler in the program for that matter).  For example, suppose the program uses malloc and free but not calloc and is statically linked against tcmalloc (built with -flto) and LTO is done.  Then before this patch the calloc alias would be deleted by LTO due to it not being used by the program, but the malloc/free aliases would be kept because they are used by the program.  Suppose the program is dynamically linked with a shared library that allocates memory using calloc and later frees it by calling free.  Then calloc will use the libc memory allocator, because the calloc alias was deleted, but free will call into tcmalloc, resulting in a crash.