### PR TITLE
fix build with musl libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@ AC_HEADER_STDC
 AC_CHECK_TYPES([__int64])       # defined in some windows platforms
 AC_CHECK_TYPES([struct mallinfo],,, [#include <malloc.h>])
 AC_CHECK_TYPES([Elf32_Versym],,, [#include <elf.h>])   # for vdso_support.h
+AC_CHECK_FUNCS(__sbrk)		# for interception on glibc
 AC_CHECK_FUNCS(sbrk)            # for tcmalloc to get memory
 AC_CHECK_FUNCS(geteuid)         # for turning off services when run as root
 AC_CHECK_FUNCS(fork)            # for the pthread_atfork setup

--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -2166,9 +2166,9 @@ struct kernel_stat {
                          int,                     t, int,       p)
   #endif
   #if defined(__x86_64__)
-    /* Need to make sure __off64_t isn't truncated to 32-bits under x32.  */
+    /* Need to make sure off64_t isn't truncated to 32-bits under x32.  */
     LSS_INLINE void* LSS_NAME(mmap)(void *s, size_t l, int p, int f, int d,
-                                    __off64_t o) {
+                                    off64_t o) {
       LSS_BODY(6, void*, mmap, LSS_SYSCALL_ARG(s), LSS_SYSCALL_ARG(l),
                                LSS_SYSCALL_ARG(p), LSS_SYSCALL_ARG(f),
                                LSS_SYSCALL_ARG(d), (uint64_t)(o));

--- a/src/malloc_hook_mmap_linux.h
+++ b/src/malloc_hook_mmap_linux.h
@@ -56,7 +56,7 @@
 
 static inline void* do_mmap64(void *start, size_t length,
                               int prot, int flags,
-                              int fd, __off64_t offset) __THROW {
+                              int fd, off64_t offset) __THROW {
   return sys_mmap(start, length, prot, flags, fd, offset);
 }
 
@@ -67,7 +67,7 @@ static inline void* do_mmap64(void *start, size_t length,
 
 static inline void* do_mmap64(void *start, size_t length,
                               int prot, int flags,
-                              int fd, __off64_t offset) __THROW {
+                              int fd, off64_t offset) __THROW {
   void *result;
 
   // Try mmap2() unless it's not supported
@@ -138,7 +138,7 @@ static inline void* do_mmap64(void *start, size_t length,
 
 extern "C" {
   void* mmap64(void *start, size_t length, int prot, int flags,
-               int fd, __off64_t offset  ) __THROW
+               int fd, off64_t offset  ) __THROW
     ATTRIBUTE_SECTION(malloc_hook);
   void* mmap(void *start, size_t length,int prot, int flags,
              int fd, off_t offset) __THROW
@@ -153,7 +153,7 @@ extern "C" {
 }
 
 extern "C" void* mmap64(void *start, size_t length, int prot, int flags,
-                        int fd, __off64_t offset) __THROW {
+                        int fd, off64_t offset) __THROW {
   MallocHook::InvokePreMmapHook(start, length, prot, flags, fd, offset);
   void *result;
   if (!MallocHook::InvokeMmapReplacement(
@@ -164,7 +164,7 @@ extern "C" void* mmap64(void *start, size_t length, int prot, int flags,
   return result;
 }
 
-# if !defined(__USE_FILE_OFFSET64) || !defined(__REDIRECT_NTH)
+# if defined(__GLIBC__) && (!defined(__USE_FILE_OFFSET64) || !defined(__REDIRECT_NTH))
 
 extern "C" void* mmap(void *start, size_t length, int prot, int flags,
                       int fd, off_t offset) __THROW {
@@ -202,7 +202,7 @@ extern "C" void* mremap(void* old_addr, size_t old_size, size_t new_size,
   return result;
 }
 
-#ifndef __UCLIBC__
+#if HAVE___SBRK
 // libc's version:
 extern "C" void* __sbrk(ptrdiff_t increment);
 


### PR DESCRIPTION
- use off64_t instead of the internal __off64_t
- during configure time, check for __sbrk function. musl libc does not
  have this. sbrk on musl libc will only work when called with 0 as
  argument, so we just let it out for now.
- only do the glibc 32-bit ABI check for mmap/mmap64 on gnu libc. musl
  does not support the 32-bit ABI.

fixes #693
