### PR TITLE
Fix various pieces of undefined behavior

### DIFF
--- a/src/base/low_level_alloc.cc
+++ b/src/base/low_level_alloc.cc
@@ -107,7 +107,7 @@ static int IntLog2(size_t size, size_t base) {
 
 // Return a random integer n:  p(n)=1/(2**n) if 1 <= n; p(n)=0 if n < 1.
 static int Random() {
-  static int32 r = 1;         // no locking---it's not critical
+  static uint32 r = 1;         // no locking---it's not critical
   ANNOTATE_BENIGN_RACE(&r, "benign race, not critical.");
   int result = 1;
   while ((((r = r*1103515245 + 12345) >> 30) & 1) == 0) {

--- a/src/tests/profile-handler_unittest.cc
+++ b/src/tests/profile-handler_unittest.cc
@@ -318,14 +318,14 @@ TEST_F(ProfileHandlerTest, RegisterUnregisterCallback) {
 // Verifies that multiple callbacks can be registered.
 TEST_F(ProfileHandlerTest, MultipleCallbacks) {
   // Register first callback.
-  int first_tick_count;
+  int first_tick_count = 0;
   ProfileHandlerToken* token1 = RegisterCallback(&first_tick_count);
   // Check that callback was registered correctly.
   VerifyRegistration(first_tick_count);
   EXPECT_EQ(1, GetCallbackCount());
 
   // Register second callback.
-  int second_tick_count;
+  int second_tick_count = 0;
   ProfileHandlerToken* token2 = RegisterCallback(&second_tick_count);
   // Check that callback was registered correctly.
   VerifyRegistration(second_tick_count);
@@ -351,13 +351,13 @@ TEST_F(ProfileHandlerTest, MultipleCallbacks) {
 TEST_F(ProfileHandlerTest, Reset) {
   // Verify that the profile timer interrupt is disabled.
   if (!linux_per_thread_timers_mode_) VerifyDisabled();
-  int first_tick_count;
+  int first_tick_count = 0;
   RegisterCallback(&first_tick_count);
   VerifyRegistration(first_tick_count);
   EXPECT_EQ(1, GetCallbackCount());
 
   // Register second callback.
-  int second_tick_count;
+  int second_tick_count = 0;
   RegisterCallback(&second_tick_count);
   VerifyRegistration(second_tick_count);
   EXPECT_EQ(2, GetCallbackCount());
@@ -384,7 +384,7 @@ TEST_F(ProfileHandlerTest, RegisterCallbackBeforeThread) {
   StartWorker();
   // Register a callback and check that profile ticks are being delivered and
   // the timer is enabled.
-  int tick_count;
+  int tick_count = 0;
   RegisterCallback(&tick_count);
   EXPECT_EQ(1, GetCallbackCount());
   VerifyRegistration(tick_count);

--- a/src/tests/sampler_test.cc
+++ b/src/tests/sampler_test.cc
@@ -604,7 +604,7 @@ TEST(Sampler, arithmetic_1) {
     CHECK_GE(q, 0); // << rnd << "  " << prng_mod_power;
   }
   // Test some potentially out of bounds value for rnd
-  for (int i = 1; i <= 66; i++) {
+  for (int i = 1; i <= 63; i++) {
     rnd = one << i;
     double q = (rnd >> (prng_mod_power - 26)) + 1.0;
     LOG(INFO) << "rnd = " << rnd << " i=" << i << " q=" << q;

--- a/src/tests/tcmalloc_unittest.cc
+++ b/src/tests/tcmalloc_unittest.cc
@@ -725,9 +725,9 @@ static void TestNothrowNew(void* (*func)(size_t, const std::nothrow_t&)) {
 // that we used the tcmalloc version of the call, and not the libc.
 // Note the ... in the hook signature: we don't care what arguments
 // the hook takes.
-#define MAKE_HOOK_CALLBACK(hook_type)                                   \
+#define MAKE_HOOK_CALLBACK(hook_type, ...)                              \
   static volatile int g_##hook_type##_calls = 0;                                 \
-  static void IncrementCallsTo##hook_type(...) {                        \
+  static void IncrementCallsTo##hook_type(__VA_ARGS__) {                \
     g_##hook_type##_calls++;                                            \
   }                                                                     \
   static void Verify##hook_type##WasCalled() {                          \
@@ -744,12 +744,14 @@ static void TestNothrowNew(void* (*func)(size_t, const std::nothrow_t&)) {
   }
 
 // We do one for each hook typedef in malloc_hook.h
-MAKE_HOOK_CALLBACK(NewHook);
-MAKE_HOOK_CALLBACK(DeleteHook);
-MAKE_HOOK_CALLBACK(MmapHook);
-MAKE_HOOK_CALLBACK(MremapHook);
-MAKE_HOOK_CALLBACK(MunmapHook);
-MAKE_HOOK_CALLBACK(SbrkHook);
+MAKE_HOOK_CALLBACK(NewHook, const void*, size_t);
+MAKE_HOOK_CALLBACK(DeleteHook, const void*);
+MAKE_HOOK_CALLBACK(MmapHook, const void*, const void*, size_t, int, int, int,
+                   off_t);
+MAKE_HOOK_CALLBACK(MremapHook, const void*, const void*, size_t, size_t, int,
+                   const void*);
+MAKE_HOOK_CALLBACK(MunmapHook, const void *, size_t);
+MAKE_HOOK_CALLBACK(SbrkHook, const void *, ptrdiff_t);
 
 static void TestAlignmentForSize(int size) {
   fprintf(LOGSTREAM, "Testing alignment of malloc(%d)\n", size);
@@ -1282,9 +1284,9 @@ static int RunAllTests(int argc, char** argv) {
     VerifyMunmapHookWasCalled();
     close(fd);
 #else   // this is just to quiet the compiler: make sure all fns are called
-    IncrementCallsToMmapHook();
-    IncrementCallsToMunmapHook();
-    IncrementCallsToMremapHook();
+    IncrementCallsToMmapHook(NULL, NULL, 0, 0, 0, 0, 0);
+    IncrementCallsToMunmapHook(NULL, 0);
+    IncrementCallsToMremapHook(NULL, NULL, 0, 0, 0, NULL);
     VerifyMmapHookWasCalled();
     VerifyMremapHookWasCalled();
     VerifyMunmapHookWasCalled();
@@ -1305,7 +1307,7 @@ static int RunAllTests(int argc, char** argv) {
     CHECK(p1 != NULL);
     CHECK_EQ(g_SbrkHook_calls, 0);
 #else   // this is just to quiet the compiler: make sure all fns are called
-    IncrementCallsToSbrkHook();
+    IncrementCallsToSbrkHook(NULL, 0);
     VerifySbrkHookWasCalled();
 #endif
 


### PR DESCRIPTION
I caught these running the gperftools tests with [ubsan](http://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) and maybe [msan](http://clang.llvm.org/docs/MemorySanitizer.html) (don't remember if ubsan or msan caught uninitialized values first).