### PR TITLE
Fix symbol resolution on OSX

### DIFF
--- a/src/pprof
+++ b/src/pprof
@@ -4572,7 +4572,11 @@ sub ParseLibraries {
     # into a single entry that spans the complete address range.
     if ($lib eq $priorlib) {
       my $prior = pop(@{$result});
-      $start = @$prior[1];
+      if ($start gt @$prior[1]) {
+        $start = @$prior[1];
+      } else {
+        $finish = @$prior[2];
+      }
       # TODO $offset may be wrong if .text is not in the final segment.
     }
 


### PR DESCRIPTION
The library mapping ranges on OSX and Linux are sorted in opposite orders

```
  7f71c3323000-7f71c3339000 r-xp 00000000 09:02 29099128                   /lib/x86_64-linux-gnu/libz.so.1.2.3.4
  7f71c3339000-7f71c3538000 ---p 00016000 09:02 29099128                   /lib/x86_64-linux-gnu/libz.so.1.2.3.4
  7f71c3538000-7f71c3539000 r--p 00015000 09:02 29099128                   /lib/x86_64-linux-gnu/libz.so.1.2.3.4
  7f71c3539000-7f71c353a000 rw-p 00016000 09:02 29099128                   /lib/x86_64-linux-gnu/libz.so.1.2.3.4
```

vs

```
  108f8d000-108f95000 r-xp 00025000 00:00 0           /usr/local/opt/libmemcached/lib/libmemcached.11.dylib
  108f8c000-108f8d000 r-xp 00024000 00:00 0           /usr/local/opt/libmemcached/lib/libmemcached.11.dylib
  108f68000-108f8c000 r-xp 00000000 00:00 0           /usr/local/opt/libmemcached/lib/libmemcached.11.dylib
```

fixes #565, #363, #752
cc #199 