### PR TITLE
Size class statistics API

### DIFF
--- a/src/central_freelist.h
+++ b/src/central_freelist.h
@@ -74,6 +74,12 @@ class CentralFreeList {
   // Returns the number of free objects in the transfer cache.
   int tc_length();
 
+  // Returns the number of spans in both the empty and nonempty freelists.
+  int spans() {
+    SpinLockHolder h(&lock_);
+    return num_spans_;
+  }
+
   // Returns the memory overhead (internal fragmentation) attributable
   // to the freelist.  This is memory lost when the size of elements
   // in a freelist doesn't exactly divide the page-size (an 8192-byte

--- a/src/gperftools/malloc_extension.h
+++ b/src/gperftools/malloc_extension.h
@@ -69,6 +69,7 @@ typedef std::string MallocExtensionWriter;
 
 namespace base {
 struct MallocRange;
+struct MallocSizeClass;
 }
 
 // Interface to a pluggable system allocator.
@@ -404,6 +405,11 @@ class PERFTOOLS_DLL_DECL MallocExtension {
   // have an empty cache but will not need to pay to reconstruct the
   // cache data structures.
   virtual void MarkThreadTemporarilyIdle();
+
+  // Invokes func(arg, classinfo) for every size class.
+  // *classinfo is filled in with information about the size class.
+  typedef void (SizeClassFunction)(void*, const base::MallocSizeClass*);
+  virtual void SizeClasses(void* arg, SizeClassFunction func);
 };
 
 namespace base {
@@ -427,6 +433,17 @@ struct MallocRange {
   // - stack trace if this range was sampled
   // - heap growth stack trace if applicable to this range
   // - age when allocated (for inuse) or freed (if not in use)
+};
+
+struct MallocSizeClass {
+    uint64_t bytes_per_obj;
+    uint64_t pages_per_span;
+    uint64_t num_spans;
+    uint64_t num_thread_objs;
+    uint64_t num_central_objs;
+    uint64_t num_transfer_objs;
+    uint64_t free_bytes;
+    uint64_t alloc_bytes;
 };
 
 } // namespace base

--- a/src/malloc_extension.cc
+++ b/src/malloc_extension.cc
@@ -118,6 +118,7 @@ bool MallocExtension::GetNumericProperty(const char* property, size_t* value) {
   return false;
 }
 
+
 bool MallocExtension::SetNumericProperty(const char* property, size_t value) {
   return false;
 }
@@ -349,6 +350,10 @@ void MallocExtension::Ranges(void* arg, RangeFunction func) {
   // No callbacks by default
 }
 
+void MallocExtension::SizeClasses(void* arg, SizeClassFunction func) {
+  // Do nothing by default
+}
+
 // These are C shims that work on the current instance.
 
 #define C_SHIM(fn, retval, paramlist, arglist)          \
@@ -370,6 +375,9 @@ C_SHIM(GetNumericProperty, int,
        (const char* property, size_t* value), (property, value));
 C_SHIM(SetNumericProperty, int,
        (const char* property, size_t value), (property, value));
+C_SHIM(SizeClasses, void,
+       (void* arg, void (func)(void*, const base::MallocSizeClass*)),
+       (arg, func));
 
 C_SHIM(MarkThreadIdle, void, (void), ());
 C_SHIM(MarkThreadBusy, void, (void), ());

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -639,6 +639,31 @@ class TCMallocImplementation : public MallocExtension {
     IterateOverRanges(arg, func);
   }
 
+  virtual void SizeClasses(void* arg, SizeClassFunction func) {
+    TCMallocStats global_stats;
+    base::MallocSizeClass stats;
+    uint64_t class_count[kNumClasses];
+    ExtractStats(&global_stats, class_count, NULL, NULL);
+
+    for (int cl = 0; cl < kNumClasses; cl++) {
+      uint64_t central_objs = Static::central_cache()[cl].length();
+      uint64_t transfer_objs = Static::central_cache()[cl].tc_length();
+      uint64_t num_spans = Static::central_cache()[cl].spans();
+      uint64_t pages_per_span = Static::sizemap()->class_to_pages(cl);
+
+      stats.bytes_per_obj = Static::sizemap()->ByteSizeForClass(cl);
+      stats.pages_per_span = pages_per_span;
+      stats.num_spans = num_spans;
+      stats.num_central_objs = central_objs;
+      stats.num_transfer_objs = transfer_objs;
+      stats.num_thread_objs = class_count[cl] - central_objs - transfer_objs;
+      stats.free_bytes = class_count[cl] * Static::sizemap()->ByteSizeForClass(cl);
+      stats.alloc_bytes = (num_spans * pages_per_span) << kPageShift;
+
+      func(arg, &stats);
+    }
+  }
+
   virtual bool GetNumericProperty(const char* name, size_t* value) {
     ASSERT(name != NULL);
 


### PR DESCRIPTION
**TL;DR**: I think exposing a size class API is valuable despite the discussion in #746.

This patch adds an API for extracting information about central freelist size classes beyond
what is already provided in `DumpStats()`. A callback can be registered to extract statistics from `SizeClasses` on a per-size class basis, which is somewhat similar to how `Ranges` works.

In #746, there are some questions as to why such an API would be useful. We're [investigating TCMalloc fragmentation issues in MongoDB](https://groups.google.com/d/topic/gperftools/gilTxIMuzqY/discussion) and it is generally useful to see which size classes are experiencing fragmentation and where the memory is being held (central, transfer, thread cache).

Some observations:
- `DumpStats()` provides some size class information but does not go into this level of detail. It also exposes this is a giant text blob, which is inefficient to both generate and parse.
- I acknowledge that a struct is not the most portable way to expose the statistics, but it is efficient. I could add a version number to it at the cost of some elegance.
- I understand that this is a TCMalloc-specific detail and not a generic malloc statistic. The default implementation does nothing, to support implementations where there is no notion of size classes.
