### PR TITLE
Small performance tweak: avoid calling time() if we don't need it

### DIFF
--- a/src/heap-profiler.cc
+++ b/src/heap-profiler.cc
@@ -272,7 +272,7 @@ static void MaybeDumpProfileLocked() {
     const int64 inuse_bytes = total.alloc_size - total.free_size;
     bool need_to_dump = false;
     char buf[128];
-    int64 current_time = time(NULL);
+
     if (FLAGS_heap_profile_allocation_interval > 0 &&
         total.alloc_size >=
         last_dump_alloc + FLAGS_heap_profile_allocation_interval) {
@@ -293,13 +293,15 @@ static void MaybeDumpProfileLocked() {
       snprintf(buf, sizeof(buf), "%" PRId64 " MB currently in use",
                inuse_bytes >> 20);
       need_to_dump = true;
-    } else if (FLAGS_heap_profile_time_interval > 0 &&
-               current_time - last_dump_time >=
-               FLAGS_heap_profile_time_interval) {
-      snprintf(buf, sizeof(buf), "%" PRId64 " sec since the last dump",
-               current_time - last_dump_time);
-      need_to_dump = true;
-      last_dump_time = current_time;
+    } else if (FLAGS_heap_profile_time_interval > 0 ) {
+      int64 current_time = time(NULL);
+      if (current_time - last_dump_time >=
+          FLAGS_heap_profile_time_interval) {
+        snprintf(buf, sizeof(buf), "%" PRId64 " sec since the last dump",
+                 current_time - last_dump_time);
+        need_to_dump = true;
+        last_dump_time = current_time;
+      }
     }
     if (need_to_dump) {
       DumpProfileLocked(buf);


### PR DESCRIPTION
time() is a system call, which might lead to performance overhead.