### PR TITLE
Remove references to __malloc_initialize_hook

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -456,16 +456,6 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([#if defined(__GNUC__) && ((__GNUC__ < 4) || (__
                 AC_MSG_RESULT([yes])],
                [AC_MSG_RESULT([no])])
 
-# glibc's __malloc_hook/etc were declared volatile starting in glibc 2.14
-AC_MSG_CHECKING([if __malloc_hook is declared volatile])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <malloc.h>
-void* (* volatile __malloc_hook)(size_t, const void*) = 0;],)],
-                  [AC_DEFINE(MALLOC_HOOK_MAYBE_VOLATILE, volatile,
-                             Define to 'volatile' if __malloc_hook is declared volatile)
-                   AC_MSG_RESULT([yes])],
-                  [AC_DEFINE(MALLOC_HOOK_MAYBE_VOLATILE, )
-                   AC_MSG_RESULT([no])])
-
 # Nanosleep requires extra libraries on some architectures (solaris).
 # This sets NANOSLEEP_LIBS.  nanosleep doesn't exist on mingw, which
 # is fine for us because we don't compile libspinlock, which uses it.

--- a/src/libc_override_glibc.h
+++ b/src/libc_override_glibc.h
@@ -86,40 +86,6 @@ extern "C" {
 
 #endif  // #if defined(__GNUC__) && !defined(__MACH__)
 
-
-// We also have to hook libc malloc.  While our work with weak symbols
-// should make sure libc malloc is never called in most situations, it
-// can be worked around by shared libraries with the DEEPBIND
-// environment variable set.  The below hooks libc to call our malloc
-// routines even in that situation.  In other situations, this hook
-// should never be called.
-extern "C" {
-static void* glibc_override_malloc(size_t size, const void *caller) {
-  return tc_malloc(size);
-}
-static void* glibc_override_realloc(void *ptr, size_t size,
-                                    const void *caller) {
-  return tc_realloc(ptr, size);
-}
-static void glibc_override_free(void *ptr, const void *caller) {
-  tc_free(ptr);
-}
-static void* glibc_override_memalign(size_t align, size_t size,
-                                     const void *caller) {
-  return tc_memalign(align, size);
-}
-
-void* (* MALLOC_HOOK_MAYBE_VOLATILE __malloc_hook)(size_t, const void*)
-    = &glibc_override_malloc;
-void* (* MALLOC_HOOK_MAYBE_VOLATILE __realloc_hook)(void*, size_t, const void*)
-    = &glibc_override_realloc;
-void (* MALLOC_HOOK_MAYBE_VOLATILE __free_hook)(void*, const void*)
-    = &glibc_override_free;
-void* (* MALLOC_HOOK_MAYBE_VOLATILE __memalign_hook)(size_t,size_t, const void*)
-    = &glibc_override_memalign;
-
-}   // extern "C"
-
 // No need to write ReplaceSystemAlloc(); one of the #includes above
 // did it for us.
 

--- a/src/libc_override_glibc.h
+++ b/src/libc_override_glibc.h
@@ -109,26 +109,6 @@ static void* glibc_override_memalign(size_t align, size_t size,
   return tc_memalign(align, size);
 }
 
-// We should be using __malloc_initialize_hook here, like the #if 0
-// code below.  (See http://swoolley.org/man.cgi/3/malloc_hook.)
-// However, this causes weird linker errors with programs that link
-// with -static, so instead we just assign the vars directly at
-// static-constructor time.  That should serve the same effect of
-// making sure the hooks are set before the first malloc call the
-// program makes.
-#if 0
-#include <malloc.h>  // for __malloc_hook, etc.
-void glibc_override_malloc_init_hook(void) {
-  __malloc_hook = glibc_override_malloc;
-  __realloc_hook = glibc_override_realloc;
-  __free_hook = glibc_override_free;
-  __memalign_hook = glibc_override_memalign;
-}
-
-void (* MALLOC_HOOK_MAYBE_VOLATILE __malloc_initialize_hook)(void)
-    = &glibc_override_malloc_init_hook;
-#endif
-
 void* (* MALLOC_HOOK_MAYBE_VOLATILE __malloc_hook)(size_t, const void*)
     = &glibc_override_malloc;
 void* (* MALLOC_HOOK_MAYBE_VOLATILE __realloc_hook)(void*, size_t, const void*)


### PR DESCRIPTION
__malloc_initialize_hook has been deprecated in glibc since 2011 and is
being removed on glibc 2.24.