### PR TITLE
Fix redefinition of mmap on aarch64.

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -2560,10 +2560,6 @@ struct kernel_stat {
   #endif
   #if (defined(__aarch64__)) || \
       (defined(__mips__) && (_MIPS_ISA == _MIPS_ISA_MIPS64))
-    LSS_INLINE _syscall6(void*, mmap,              void*, s,
-                         size_t,                   l, int,               p,
-                         int,                      f, int,               d,
-                         __off64_t,                o)
     LSS_INLINE int LSS_NAME(sigaction)(int signum,
                                        const struct kernel_sigaction *act,
                                        struct kernel_sigaction *oldact) {


### PR DESCRIPTION
The error was

```
src/base/linux_syscall_support.h: In function ‘void* sys_mmap(void*, size_t, int, int, int, int64_t)’:
src/base/linux_syscall_support.h:975:28: error: redefinition of ‘void* sys_mmap(void*, size_t, int, int, int, int64_t)’
     #define LSS_NAME(name) sys_##name
                            ^
src/base/linux_syscall_support.h:2253:12: note: in expansion of macro ‘LSS_NAME’
       type LSS_NAME(name)(type1 arg1, type2 arg2, type3 arg3, type4 arg4,     \
            ^
src/base/linux_syscall_support.h:2783:16: note: in expansion of macro ‘_syscall6’
     LSS_INLINE _syscall6(void*, mmap, void*, addr, size_t, length, int, prot,
                ^
src/base/linux_syscall_support.h:975:28: note: ‘void* sys_mmap(void*, size_t, int, int, int, __off64_t)’ previously defined here
     #define LSS_NAME(name) sys_##name
                            ^
src/base/linux_syscall_support.h:2253:12: note: in expansion of macro ‘LSS_NAME’
       type LSS_NAME(name)(type1 arg1, type2 arg2, type3 arg3, type4 arg4,     \
            ^
src/base/linux_syscall_support.h:2563:16: note: in expansion of macro ‘_syscall6’
     LSS_INLINE _syscall6(void*, mmap,              void*, s,
```