### PR TITLE
Update linux_syscall_support.h

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -2779,9 +2779,7 @@ struct kernel_stat {
                                LSS_SYSCALL_ARG(d), (uint64_t)(o));
     }
   #else
-    /* Remaining 64-bit architectures. */
-    LSS_INLINE _syscall6(void*, mmap, void*, addr, size_t, length, int, prot,
-                         int, flags, int, fd, int64_t, offset)
+    #error "Unsupported 64-bit architecture"
   #endif
   #if defined(__i386__) || \
       defined(__PPC__) || \


### PR DESCRIPTION
The #else here defines `__syscall6` twice for `__aarch64__`. The first time is up on line 2563. Instead of a catchall for other 64-bit architectures, they can be handled explicitly.

@alk 