### PR TITLE
Fix occasional crush on x86_64 environment

### DIFF
--- a/src/stacktrace_x86-inl.h
+++ b/src/stacktrace_x86-inl.h
@@ -135,21 +135,6 @@ static int CountPushInstructions(const unsigned char *const addr) {
 }
 #endif
 
-// Get stack bottom of current thread
-static void* GetStackBottom() {
-  static __thread void* result;
-  if (!result) {
-    char frame;
-    uintptr_t page_size = getpagesize();
-    char* aligned_p = (char *)((uintptr_t)&frame & ~(page_size - 1));
-    while (msync(aligned_p, page_size, MS_ASYNC) != -1) {
-      aligned_p += page_size;  // x86 stack is growdown
-    }
-    result = aligned_p;
-  }
-  return result;
-}
-
 // Given a pointer to a stack frame, locate and return the calling
 // stackframe, or return NULL if no stackframe can be found. Perform sanity
 // checks (the strictness of which is controlled by the boolean parameter
@@ -271,20 +256,17 @@ static void **NextStackFrame(void **old_sp, const void *uc) {
   if ((uintptr_t)new_sp >= 0xffffe000) return NULL;
 #endif
 #ifdef HAVE_MMAP
-  if (!STRICT_UNWINDING) {
-    // Lax sanity checks cause a crash on AMD-based machines with
-    // VDSO-enabled kernels.
-    // Make an extra sanity check to insure new_sp is readable.
-    // Note: NextStackFrame<false>() is only called while the program
-    //       is already on its last leg, so it's ok to be slow here.
-    static int page_size = getpagesize();
-    void *new_sp_aligned = (void *)((uintptr_t)new_sp & ~(page_size - 1));
+  // Lax sanity checks cause a crash on AMD-based machines with
+  // VDSO-enabled kernels.
+  // Make an extra sanity check to insure new_sp is readable.
+  // Note: NextStackFrame<false>() is only called while the program
+  //       is already on its last leg, so it's ok to be slow here.
+  static int page_size = getpagesize();
+  void *new_sp_aligned = (void *)((uintptr_t)new_sp & ~(page_size - 1));
+  void *old_sp_aligned = (void *)((uintptr_t)old_sp & ~(page_size - 1));
+  // old_sp is readable, so new_sp must be readable if it is in the same page.
+  if (new_sp_aligned != old_sp_aligned) {
     if (msync(new_sp_aligned, page_size, MS_ASYNC) == -1)
-      return NULL;
-  } else {
-    // In some case returned invalid result also crash the whole process.
-    // This is a cheaper checking than above(msync), but is still work well.
-    if (new_sp > GetStackBottom())
       return NULL;
   }
 #endif


### PR DESCRIPTION
Issue description:
With HEAPCHECK enabled environment, My program crash here occasionally.
```
// gperftools-2.4/src/stacktrace_x86-inl.h
 327       while (sp && n < max_depth) {
>328         if (*(sp+1) == reinterpret_cast<void *>(0)) {
 329           // In 64-bit code, we often see a frame that
 330           // points to itself and has a return address of 0.
 331           break;
 332         }

```   
with call stack
```
*** SIGSEGV (@0x7fff6e5999a8) received by PID 27560 (TID 0x7f2fa8fff9c0) from PID 1851365800; stack trace: ***
    @     0x7f2f94bbe710 (unknown)
    @     0x7f2f949a65d0 GetStackTrace_x86()
    @     0x7f2f949a6ba6 GetStackTrace()
    @     0x7f2f94df435a MallocHook_GetCallerStackTrace
    @     0x7f2f94e0669f HeapProfileTable::GetCallerStackTrace()
    @     0x7f2f94dfb593 NewHook()
    @     0x7f2f94df37fa MallocHook::InvokeNewHookSlow()
    @     0x7f2f9506dc39 operator new()

```
Analysis:
For performance reason, our gperftools was not configured with libunwinding,
and all our code compiled with -fno-omit-frame-pointer, but for system libraries such as glibc, we kept them unchanged, which are compiled with -fomit-frame-pointer by default. maybe it is the reason of crash.

Solution:
I noticed that msync was used in other paths to check the validity of pointer, but maybe because it is slow, It is not enabled in normal path.
So I provide an optimized implementation.

I've already signed CLA the several years ago, in the age of googlecode. so I'm glad to contribute this change.