### PR TITLE
Fix a possible infinite loop in TCMalloc_ListAllProcessThreads.

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -205,7 +205,7 @@ struct kernel_dirent64 {
   long long          d_off;
   unsigned short     d_reclen;
   unsigned char      d_type;
-  char               d_name[256];
+  char               d_name[0];
 };
 
 /* include/linux/dirent.h                                                    */
@@ -213,7 +213,7 @@ struct kernel_dirent {
   long               d_ino;
   long               d_off;
   unsigned short     d_reclen;
-  char               d_name[256];
+  char               d_name[0];
 };
 
 /* include/linux/time.h                                                      */

--- a/src/base/linuxthreads.cc
+++ b/src/base/linuxthreads.cc
@@ -388,9 +388,15 @@ static void ListerThread(struct ListerParams *args) {
             continue;
           }
           break;
+        } else if (nbytes < sizeof(struct KERNEL_DIRENT)) {
+          /* Couldn't read the header part of the first entry. Retry. */
+          added_entries = 0;
+          sys_lseek(proc, 0, SEEK_SET);
+          continue;
         }
         for (entry = (struct KERNEL_DIRENT *)buf;
-             entry < (struct KERNEL_DIRENT *)&buf[nbytes];
+             (entry < (struct KERNEL_DIRENT *)&buf[nbytes] &&
+              (char*)entry + entry->d_reclen <= &buf[nbytes]);
              entry = (struct KERNEL_DIRENT *)((char *)entry+entry->d_reclen)) {
           if (entry->d_ino != 0) {
             const char *ptr = entry->d_name;


### PR DESCRIPTION
The ListerThread may access the buffer out of bounds. I have seen this thread using 100% cpu and running forever. I'm not sure if this change fixes the problem, but the original code looks suspicious.