### PR TITLE
Fix compilation error for powerpc32

### DIFF
--- a/src/stacktrace_powerpc-linux-inl.h
+++ b/src/stacktrace_powerpc-linux-inl.h
@@ -44,6 +44,7 @@
 
 #include <stdint.h>   // for uintptr_t
 #include <stdlib.h>   // for NULL
+#include <signal.h>  // for siginfo_t
 #include <gperftools/stacktrace.h>
 #include <base/vdso_support.h>
 


### PR DESCRIPTION
Fix the following compilation error for powerpc32 platform when using
latest glibc.
error: ‘siginfo_t’ was not declared in this scope