### PR TITLE
remove superfluous size_t value >= 0 check

### DIFF
--- a/src/debugallocation.cc
+++ b/src/debugallocation.cc
@@ -619,7 +619,6 @@ class MallocBlock {
         free_queue_lock_.Lock();
       }
     }
-    RAW_CHECK(free_queue_size_ >= 0, "Free queue size went negative!");
     free_queue_lock_.Unlock();
     for (int i = 0; i < num_entries; i++) {
       CheckForDanglingWrites(entries[i]);


### PR DESCRIPTION
This assertion adds no value, and can trigger warnings (and errors if you build with -Werror).  I think it should be removed.  If it is really important, a comment where the variable is defined would suffice.