### PR TITLE
Document HEAPPROFILESIGNAL environment variable

### DIFF
--- a/docs/heapprofile.html
+++ b/docs/heapprofile.html
@@ -115,6 +115,15 @@ environment variables.</p>
 </tr>
 
 <tr valign=top>
+  <td><code>HEAPPROFILESIGNAL</code></td>
+  <td>default: disabled</td>
+  <td>
+    Dump heap profiling information whenever the specified signal is sent to the
+    process.
+  </td>
+</tr>
+
+<tr valign=top>
   <td><code>HEAP_PROFILE_MMAP</code></td>
   <td>default: false</td>
   <td>


### PR DESCRIPTION
We've found this relatively new config option highly useful. It would be nice if it was included in the user-facing documentation.