### PR TITLE
Ignore current_instance heap allocation when leak sanitizer is enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,9 @@ TCMALLOC_FLAGS =
 if MINGW
 TCMALLOC_FLAGS += -Wl,-u__tcmalloc
 endif MINGW
+if OSX
+AM_LDFLAGS += -Wl,-U,___lsan_ignore_object
+endif OSX
 
 # If we have objcopy, make malloc/free/etc weak symbols.  That way folks
 # can override our malloc if they want to (they can still use tc_malloc).

--- a/src/malloc_extension.cc
+++ b/src/malloc_extension.cc
@@ -205,6 +205,16 @@ void MallocExtension::MarkThreadTemporarilyIdle() {
 
 static MallocExtension* current_instance;
 
+#if (!defined(_WIN32) && !defined(__MINGW32__))
+// Provide a weak hook for __lsan_ignore_object, so that
+// if leak sanitizer is enabled, we can ignore the current_instance
+// heap allocation.
+extern "C" void __attribute__((weak)) __lsan_ignore_object(const void *);
+#else
+// Weak hooks aren't supported on windows, but neither is leak sanitizer.
+void (*__lsan_ignore_object)(const void *) = nullptr;
+#endif
+
 static void InitModule() {
   if (current_instance != NULL) {
     return;
@@ -213,6 +223,9 @@ static void InitModule() {
 #ifndef NO_HEAP_CHECK
   HeapLeakChecker::IgnoreObject(current_instance);
 #endif
+  if (__lsan_ignore_object) {
+    __lsan_ignore_object(current_instance);
+  }
 }
 
 REGISTER_MODULE_INITIALIZER(malloc_extension_init, InitModule())


### PR DESCRIPTION
Without this patch, any user program that enables LeakSanitizer will
see a leak from tcmalloc. Add a weak hook to __lsan_ignore_object,
so that if LeakSanitizer is enabled, the allocation can be ignored.