### PR TITLE
Fix c++17 build

### DIFF
--- a/src/base/basictypes.h
+++ b/src/base/basictypes.h
@@ -433,4 +433,11 @@ namespace base {
 enum LinkerInitialized { LINKER_INITIALIZED };
 }
 
+#if __cpp_noexcept_function_type >= 201510
+// Deprecated in C++17
+# define PERFTOOLS_THROW(...)
+#else
+# define PERFTOOLS_THROW(...) throw(__VA_ARGS__)
+#endif
+
 #endif  // _BASICTYPES_H_

--- a/src/debugallocation.cc
+++ b/src/debugallocation.cc
@@ -1227,7 +1227,7 @@ static void force_frame() {
   (void)dummy;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_NOTHROW {
   if (ThreadCache::IsUseEmergencyMalloc()) {
     return tcmalloc::EmergencyMalloc(size);
   }
@@ -1236,7 +1236,7 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_THROW {
   return ptr;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_NOTHROW {
   if (tcmalloc::IsEmergencyPtr(ptr)) {
     return tcmalloc::EmergencyFree(ptr);
   }
@@ -1245,13 +1245,13 @@ extern "C" PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_THROW {
   force_frame();
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(ptr);
   DebugDeallocate(ptr, MallocBlock::kMallocType, size);
   force_frame();
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_calloc(size_t count, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_calloc(size_t count, size_t size) PERFTOOLS_NOTHROW {
   if (ThreadCache::IsUseEmergencyMalloc()) {
     return tcmalloc::EmergencyCalloc(count, size);
   }
@@ -1265,7 +1265,7 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_calloc(size_t count, size_t size) PERFTOO
   return block;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_NOTHROW {
   if (tcmalloc::IsEmergencyPtr(ptr)) {
     return tcmalloc::EmergencyFree(ptr);
   }
@@ -1274,7 +1274,7 @@ extern "C" PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_THROW {
   force_frame();
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_NOTHROW {
   if (tcmalloc::IsEmergencyPtr(ptr)) {
     return tcmalloc::EmergencyRealloc(ptr, size);
   }
@@ -1324,19 +1324,19 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_new(size_t size) {
   return ptr;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_NOTHROW {
   void* ptr = debug_cpp_alloc(size, MallocBlock::kNewType, true);
   MallocHook::InvokeNewHook(ptr, size);
   return ptr;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(p);
   DebugDeallocate(p, MallocBlock::kNewType, 0);
   force_frame();
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(p);
   DebugDeallocate(p, MallocBlock::kNewType, size);
   force_frame();
@@ -1344,7 +1344,7 @@ extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOO
 
 // Some STL implementations explicitly invoke this.
 // It is completely equivalent to a normal delete (delete never throws).
-extern "C" PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(p);
   DebugDeallocate(p, MallocBlock::kNewType, 0);
   force_frame();
@@ -1360,19 +1360,19 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_newarray(size_t size) {
 }
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size, const std::nothrow_t&)
-    PERFTOOLS_THROW {
+    PERFTOOLS_NOTHROW {
   void* ptr = debug_cpp_alloc(size, MallocBlock::kArrayNewType, true);
   MallocHook::InvokeNewHook(ptr, size);
   return ptr;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(p);
   DebugDeallocate(p, MallocBlock::kArrayNewType, 0);
   force_frame();
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(p);
   DebugDeallocate(p, MallocBlock::kArrayNewType, size);
   force_frame();
@@ -1380,7 +1380,7 @@ extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PE
 
 // Some STL implementations explicitly invoke this.
 // It is completely equivalent to a normal delete (delete never throws).
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_NOTHROW {
   MallocHook::InvokeDeleteHook(p);
   DebugDeallocate(p, MallocBlock::kArrayNewType, 0);
   force_frame();
@@ -1443,7 +1443,7 @@ inline void* do_debug_memalign_or_debug_cpp_memalign(size_t align,
                     false, true);
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_memalign(size_t align, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_memalign(size_t align, size_t size) PERFTOOLS_NOTHROW {
   void *p = do_debug_memalign_or_debug_cpp_memalign(align, size);
   MallocHook::InvokeNewHook(p, size);
   return p;
@@ -1451,7 +1451,7 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_memalign(size_t align, size_t size) PERFT
 
 // Implementation taken from tcmalloc/tcmalloc.cc
 extern "C" PERFTOOLS_DLL_DECL int tc_posix_memalign(void** result_ptr, size_t align, size_t size)
-    PERFTOOLS_THROW {
+    PERFTOOLS_NOTHROW {
   if (((align % sizeof(void*)) != 0) ||
       ((align & (align - 1)) != 0) ||
       (align == 0)) {
@@ -1468,14 +1468,14 @@ extern "C" PERFTOOLS_DLL_DECL int tc_posix_memalign(void** result_ptr, size_t al
   }
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_valloc(size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_valloc(size_t size) PERFTOOLS_NOTHROW {
   // Allocate >= size bytes starting on a page boundary
   void *p = do_debug_memalign_or_debug_cpp_memalign(getpagesize(), size);
   MallocHook::InvokeNewHook(p, size);
   return p;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_NOTHROW {
   // Round size up to a multiple of pages
   // then allocate memory on a page boundary
   int pagesize = getpagesize();
@@ -1489,25 +1489,25 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_THROW {
 }
 
 // malloc_stats just falls through to the base implementation.
-extern "C" PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_NOTHROW {
   do_malloc_stats();
 }
 
-extern "C" PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW {
   return do_mallopt(cmd, value);
 }
 
 #ifdef HAVE_STRUCT_MALLINFO
-extern "C" PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW {
   return do_mallinfo();
 }
 #endif
 
-extern "C" PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_NOTHROW {
   return MallocExtension::instance()->GetAllocatedSize(ptr);
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_NOTHROW {
   void* result = DebugAllocate(size, MallocBlock::kMallocType);
   MallocHook::InvokeNewHook(result, size);
   return result;

--- a/src/gperftools/tcmalloc.h.in
+++ b/src/gperftools/tcmalloc.h.in
@@ -49,17 +49,17 @@
 # include <malloc.h>
 #endif
 
-#ifndef PERFTOOLS_THROW
+#ifndef PERFTOOLS_NOTHROW
 
 #if __cplusplus >= 201103L
-#define PERFTOOLS_THROW noexcept
+#define PERFTOOLS_NOTHROW noexcept
 #elif defined(__cplusplus)
-#define PERFTOOLS_THROW throw()
+#define PERFTOOLS_NOTHROW throw()
 #else
 # ifdef __GNUC__
-#  define PERFTOOLS_THROW __attribute__((__nothrow__))
+#  define PERFTOOLS_NOTHROW __attribute__((__nothrow__))
 # else
-#  define PERFTOOLS_THROW
+#  define PERFTOOLS_NOTHROW
 # endif
 #endif
 
@@ -86,27 +86,27 @@ extern "C" {
    * minor version, and patch-code (a string, usually "").
    */
   PERFTOOLS_DLL_DECL const char* tc_version(int* major, int* minor,
-                                            const char** patch) PERFTOOLS_THROW;
+                                            const char** patch) PERFTOOLS_NOTHROW;
 
-  PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_NOTHROW;
 
   PERFTOOLS_DLL_DECL void* tc_memalign(size_t __alignment,
-                                       size_t __size) PERFTOOLS_THROW;
+                                       size_t __size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL int tc_posix_memalign(void** ptr,
-                                           size_t align, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_valloc(size_t __size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t __size) PERFTOOLS_THROW;
+                                           size_t align, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_valloc(size_t __size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t __size) PERFTOOLS_NOTHROW;
 
-  PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW;
 #if @ac_cv_have_struct_mallinfo@
-  PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW;
 #endif
 
   /*
@@ -116,31 +116,31 @@ extern "C" {
    *    glibc: malloc_usable_size()
    *    Windows: _msize()
    */
-  PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_NOTHROW;
 
 #ifdef __cplusplus
-  PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void* tc_new(size_t size);
   PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size,
-                                          const std::nothrow_t&) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_THROW;
+                                          const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p,
-                                            const std::nothrow_t&) PERFTOOLS_THROW;
+                                            const std::nothrow_t&) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void* tc_newarray(size_t size);
   PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size,
-                                               const std::nothrow_t&) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_THROW;
+                                               const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
-                                                 const std::nothrow_t&) PERFTOOLS_THROW;
+                                                 const std::nothrow_t&) PERFTOOLS_NOTHROW;
 }
 #endif
 
 /* We're only un-defining for public */
 #if !defined(GPERFTOOLS_CONFIG_H_)
 
-#undef PERFTOOLS_THROW
+#undef PERFTOOLS_NOTHROW
 
 #endif /* GPERFTOOLS_CONFIG_H_ */
 

--- a/src/libc_override_gcc_and_weak.h
+++ b/src/libc_override_gcc_and_weak.h
@@ -59,36 +59,36 @@
 
 void* operator new(size_t size) PERFTOOLS_THROW(std::bad_alloc)
     ALIAS(tc_new);
-void operator delete(void* p) throw()
+void operator delete(void* p) PERFTOOLS_NOTHROW
     ALIAS(tc_delete);
 void* operator new[](size_t size) PERFTOOLS_THROW(std::bad_alloc)
     ALIAS(tc_newarray);
-void operator delete[](void* p) throw()
+void operator delete[](void* p) PERFTOOLS_NOTHROW
     ALIAS(tc_deletearray);
-void* operator new(size_t size, const std::nothrow_t& nt) throw()
+void* operator new(size_t size, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
     ALIAS(tc_new_nothrow);
-void* operator new[](size_t size, const std::nothrow_t& nt) throw()
+void* operator new[](size_t size, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
     ALIAS(tc_newarray_nothrow);
-void operator delete(void* p, const std::nothrow_t& nt) throw()
+void operator delete(void* p, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
     ALIAS(tc_delete_nothrow);
-void operator delete[](void* p, const std::nothrow_t& nt) throw()
+void operator delete[](void* p, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
     ALIAS(tc_deletearray_nothrow);
 
 #if defined(ENABLE_SIZED_DELETE)
 
-void operator delete(void *p, size_t size) throw()
+void operator delete(void *p, size_t size) PERFTOOLS_NOTHROW
     ALIAS(tc_delete_sized);
-void operator delete[](void *p, size_t size) throw()
+void operator delete[](void *p, size_t size) PERFTOOLS_NOTHROW
     ALIAS(tc_deletearray_sized);
 
 #elif defined(ENABLE_DYNAMIC_SIZED_DELETE) && \
   (__GNUC__ * 100 + __GNUC_MINOR__) >= 405
 
-static void delegate_sized_delete(void *p, size_t s) throw() {
+static void delegate_sized_delete(void *p, size_t s) PERFTOOLS_NOTHROW {
   (operator delete)(p);
 }
 
-static void delegate_sized_deletearray(void *p, size_t s) throw() {
+static void delegate_sized_deletearray(void *p, size_t s) PERFTOOLS_NOTHROW {
   (operator delete[])(p);
 }
 
@@ -122,16 +122,16 @@ static void *resolve_deletearray_sized(void) {
 
 }
 
-void operator delete(void *p, size_t size) throw()
+void operator delete(void *p, size_t size) PERFTOOLS_NOTHROW
   __attribute__((ifunc("resolve_delete_sized")));
-void operator delete[](void *p, size_t size) throw()
+void operator delete[](void *p, size_t size) PERFTOOLS_NOTHROW
   __attribute__((ifunc("resolve_deletearray_sized")));
 
 #else /* !ENABLE_SIZED_DELETE && !ENABLE_DYN_SIZED_DELETE */
 
-void operator delete(void *p, size_t size) throw()
+void operator delete(void *p, size_t size) PERFTOOLS_NOTHROW
   ALIAS(tc_delete);
-void operator delete[](void *p, size_t size) throw()
+void operator delete[](void *p, size_t size) PERFTOOLS_NOTHROW
   ALIAS(tc_deletearray);
 
 #endif /* !ENABLE_SIZED_DELETE && !ENABLE_DYN_SIZED_DELETE */

--- a/src/libc_override_gcc_and_weak.h
+++ b/src/libc_override_gcc_and_weak.h
@@ -57,11 +57,11 @@
 
 #define ALIAS(tc_fn)   __attribute__ ((alias (#tc_fn), used))
 
-void* operator new(size_t size) throw (std::bad_alloc)
+void* operator new(size_t size) PERFTOOLS_THROW(std::bad_alloc)
     ALIAS(tc_new);
 void operator delete(void* p) throw()
     ALIAS(tc_delete);
-void* operator new[](size_t size) throw (std::bad_alloc)
+void* operator new[](size_t size) PERFTOOLS_THROW(std::bad_alloc)
     ALIAS(tc_newarray);
 void operator delete[](void* p) throw()
     ALIAS(tc_deletearray);

--- a/src/libc_override_redefine.h
+++ b/src/libc_override_redefine.h
@@ -43,25 +43,25 @@
 #define TCMALLOC_LIBC_OVERRIDE_REDEFINE_H_
 
 void* operator new(size_t size)                  { return tc_new(size);       }
-void operator delete(void* p) throw()            { tc_delete(p);              }
+void operator delete(void* p) PERFTOOLS_NOTHROW            { tc_delete(p);              }
 void* operator new[](size_t size)                { return tc_newarray(size);  }
-void operator delete[](void* p) throw()          { tc_deletearray(p);         }
-void* operator new(size_t size, const std::nothrow_t& nt) throw() {
+void operator delete[](void* p) PERFTOOLS_NOTHROW          { tc_deletearray(p);         }
+void* operator new(size_t size, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
   return tc_new_nothrow(size, nt);
 }
-void* operator new[](size_t size, const std::nothrow_t& nt) throw() {
+void* operator new[](size_t size, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
   return tc_newarray_nothrow(size, nt);
 }
-void operator delete(void* ptr, const std::nothrow_t& nt) throw() {
+void operator delete(void* ptr, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
   return tc_delete_nothrow(ptr, nt);
 }
-void operator delete[](void* ptr, const std::nothrow_t& nt) throw() {
+void operator delete[](void* ptr, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
   return tc_deletearray_nothrow(ptr, nt);
 }
 
 #ifdef ENABLE_SIZED_DELETE
-void operator delete(void* p, size_t s) throw()  { tc_delete_sized(p, s);     }
-void operator delete[](void* p, size_t s) throw(){ tc_deletearray_sized(p);   }
+void operator delete(void* p, size_t s) PERFTOOLS_NOTHROW  { tc_delete_sized(p, s);     }
+void operator delete[](void* p, size_t s) PERFTOOLS_NOTHROW{ tc_deletearray_sized(p);   }
 #endif
 
 extern "C" {

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -91,7 +91,7 @@
 // At least for gcc on Linux/i386 and Linux/amd64 not adding throw()
 // to tc_xxx functions actually ends up generating better code.
 #ifdef __GNUC__
-#define PERFTOOLS_THROW
+#define PERFTOOLS_NOTHROW
 #endif
 #include <gperftools/tcmalloc.h>
 
@@ -198,61 +198,61 @@ DEFINE_int64(tcmalloc_large_alloc_report_threshold,
 // MallocHook::GetCallerStackTrace can function accurately.
 #ifndef _WIN32   // windows doesn't have attribute_section, so don't bother
 extern "C" {
-  void* tc_malloc(size_t size) PERFTOOLS_THROW
+  void* tc_malloc(size_t size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_free(void* ptr) PERFTOOLS_THROW
+  void tc_free(void* ptr) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_free_sized(void* ptr, size_t size) PERFTOOLS_THROW
+  void tc_free_sized(void* ptr, size_t size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void* tc_realloc(void* ptr, size_t size) PERFTOOLS_THROW
+  void* tc_realloc(void* ptr, size_t size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_THROW
+  void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_cfree(void* ptr) PERFTOOLS_THROW
-      ATTRIBUTE_SECTION(google_malloc);
-
-  void* tc_memalign(size_t __alignment, size_t __size) PERFTOOLS_THROW
-      ATTRIBUTE_SECTION(google_malloc);
-  int tc_posix_memalign(void** ptr, size_t align, size_t size) PERFTOOLS_THROW
-      ATTRIBUTE_SECTION(google_malloc);
-  void* tc_valloc(size_t __size) PERFTOOLS_THROW
-      ATTRIBUTE_SECTION(google_malloc);
-  void* tc_pvalloc(size_t __size) PERFTOOLS_THROW
+  void tc_cfree(void* ptr) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
 
-  void tc_malloc_stats(void) PERFTOOLS_THROW
+  void* tc_memalign(size_t __alignment, size_t __size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  int tc_mallopt(int cmd, int value) PERFTOOLS_THROW
+  int tc_posix_memalign(void** ptr, size_t align, size_t size) PERFTOOLS_NOTHROW
+      ATTRIBUTE_SECTION(google_malloc);
+  void* tc_valloc(size_t __size) PERFTOOLS_NOTHROW
+      ATTRIBUTE_SECTION(google_malloc);
+  void* tc_pvalloc(size_t __size) PERFTOOLS_NOTHROW
+      ATTRIBUTE_SECTION(google_malloc);
+
+  void tc_malloc_stats(void) PERFTOOLS_NOTHROW
+      ATTRIBUTE_SECTION(google_malloc);
+  int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
 #ifdef HAVE_STRUCT_MALLINFO
-  struct mallinfo tc_mallinfo(void) PERFTOOLS_THROW
+  struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
 #endif
 
   void* tc_new(size_t size)
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_delete(void* p) PERFTOOLS_THROW
+  void tc_delete(void* p) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_delete_sized(void* p, size_t size) PERFTOOLS_THROW
+  void tc_delete_sized(void* p, size_t size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
   void* tc_newarray(size_t size)
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_deletearray(void* p) PERFTOOLS_THROW
+  void tc_deletearray(void* p) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_THROW
+  void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
 
   // And the nothrow variants of these:
-  void* tc_new_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_THROW
+  void* tc_new_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void* tc_newarray_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_THROW
+  void* tc_newarray_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
   // Surprisingly, standard C++ library implementations use a
   // nothrow-delete internally.  See, eg:
   // http://www.dinkumware.com/manuals/?manual=compleat&page=new.html
-  void tc_delete_nothrow(void* ptr, const std::nothrow_t&) PERFTOOLS_THROW
+  void tc_delete_nothrow(void* ptr, const std::nothrow_t&) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
-  void tc_deletearray_nothrow(void* ptr, const std::nothrow_t&) PERFTOOLS_THROW
+  void tc_deletearray_nothrow(void* ptr, const std::nothrow_t&) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
 
   // Some non-standard extensions that we support.
@@ -261,7 +261,7 @@ extern "C" {
   //    OS X: malloc_size()
   //    glibc: malloc_usable_size()
   //    Windows: _msize()
-  size_t tc_malloc_size(void* p) PERFTOOLS_THROW
+  size_t tc_malloc_size(void* p) PERFTOOLS_NOTHROW
       ATTRIBUTE_SECTION(google_malloc);
 }  // extern "C"
 #endif  // #ifndef _WIN32
@@ -1621,7 +1621,7 @@ void TCMallocImplementation::MarkThreadBusy() {
 //-------------------------------------------------------------------
 
 extern "C" PERFTOOLS_DLL_DECL const char* tc_version(
-    int* major, int* minor, const char** patch) PERFTOOLS_THROW {
+    int* major, int* minor, const char** patch) PERFTOOLS_NOTHROW {
   if (major) *major = TC_VERSION_MAJOR;
   if (minor) *minor = TC_VERSION_MINOR;
   if (patch) *patch = TC_VERSION_PATCH;
@@ -1633,7 +1633,7 @@ extern "C" PERFTOOLS_DLL_DECL const char* tc_version(
 // If flag is 1, calls to malloc will behave like calls to new,
 // and the std_new_handler will be invoked on failure.
 // Returns the previous mode.
-extern "C" PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_NOTHROW {
   int old_mode = tc_new_mode;
   tc_new_mode = flag;
   return old_mode;
@@ -1752,12 +1752,12 @@ static void * malloc_fast_path(size_t size) {
 }
 
 extern "C" PERFTOOLS_DLL_DECL CACHELINE_ALIGNED_FN
-void* tc_malloc(size_t size) PERFTOOLS_THROW {
+void* tc_malloc(size_t size) PERFTOOLS_NOTHROW {
   return malloc_fast_path<tcmalloc::allocate_full_malloc_oom>(size);
 }
 
 extern "C" PERFTOOLS_DLL_DECL CACHELINE_ALIGNED_FN
-void tc_free(void* ptr) PERFTOOLS_THROW {
+void tc_free(void* ptr) PERFTOOLS_NOTHROW {
   if (PREDICT_FALSE(!base::internal::delete_hooks_.empty())) {
     tcmalloc::invoke_hooks_and_free(ptr);
     return;
@@ -1766,7 +1766,7 @@ void tc_free(void* ptr) PERFTOOLS_THROW {
 }
 
 extern "C" PERFTOOLS_DLL_DECL CACHELINE_ALIGNED_FN
-void tc_free_sized(void *ptr, size_t size) PERFTOOLS_THROW {
+void tc_free_sized(void *ptr, size_t size) PERFTOOLS_NOTHROW {
   if (PREDICT_FALSE(!base::internal::delete_hooks_.empty())) {
     tcmalloc::invoke_hooks_and_free(ptr);
     return;
@@ -1789,24 +1789,24 @@ void tc_free_sized(void *ptr, size_t size) PERFTOOLS_THROW {
 
 #ifdef TC_ALIAS
 
-extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void *p, size_t size) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void *p, size_t size) PERFTOOLS_NOTHROW
   TC_ALIAS(tc_free_sized);
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void *p, size_t size) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void *p, size_t size) PERFTOOLS_NOTHROW
   TC_ALIAS(tc_free_sized);
 
 #else
 
-extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void *p, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized(void *p, size_t size) PERFTOOLS_NOTHROW {
   tc_free_sized(p, size);
 }
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void *p, size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized(void *p, size_t size) PERFTOOLS_NOTHROW {
   tc_free_sized(p, size);
 }
 
 #endif
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_calloc(size_t n,
-                                              size_t elem_size) PERFTOOLS_THROW {
+                                              size_t elem_size) PERFTOOLS_NOTHROW {
   if (ThreadCache::IsUseEmergencyMalloc()) {
     return tcmalloc::EmergencyCalloc(n, elem_size);
   }
@@ -1815,7 +1815,7 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_calloc(size_t n,
   return result;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_NOTHROW
 #ifdef TC_ALIAS
 TC_ALIAS(tc_free);
 #else
@@ -1829,7 +1829,7 @@ TC_ALIAS(tc_free);
 #endif
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_realloc(void* old_ptr,
-                                               size_t new_size) PERFTOOLS_THROW {
+                                               size_t new_size) PERFTOOLS_NOTHROW {
   if (old_ptr == NULL) {
     void* result = do_malloc_or_cpp_alloc(new_size);
     MallocHook::InvokeNewHook(result, new_size);
@@ -1852,11 +1852,11 @@ void* tc_new(size_t size) {
 }
 
 extern "C" PERFTOOLS_DLL_DECL CACHELINE_ALIGNED_FN
-void* tc_new_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_THROW {
+void* tc_new_nothrow(size_t size, const std::nothrow_t&) PERFTOOLS_NOTHROW {
   return malloc_fast_path<tcmalloc::allocate_full_cpp_nothrow_oom>(size);
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_NOTHROW
 #ifdef TC_ALIAS
 TC_ALIAS(tc_free);
 #else
@@ -1872,7 +1872,7 @@ TC_ALIAS(tc_free);
 // Standard C++ library implementations define and use this
 // (via ::operator delete(ptr, nothrow)).
 // But it's really the same as normal delete, so we just do the same thing.
-extern "C" PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_NOTHROW
 #ifdef TC_ALIAS
 TC_ALIAS(tc_free);
 #else
@@ -1895,7 +1895,7 @@ TC_ALIAS(tc_new);
 #endif
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size, const std::nothrow_t&)
-    PERFTOOLS_THROW
+    PERFTOOLS_NOTHROW
 #ifdef TC_ALIAS
 TC_ALIAS(tc_new_nothrow);
 #else
@@ -1904,7 +1904,7 @@ TC_ALIAS(tc_new_nothrow);
 }
 #endif
 
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_NOTHROW
 #ifdef TC_ALIAS
 TC_ALIAS(tc_free);
 #else
@@ -1917,7 +1917,7 @@ TC_ALIAS(tc_free);
 }
 #endif
 
-extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_THROW
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p, const std::nothrow_t&) PERFTOOLS_NOTHROW
 #ifdef TC_ALIAS
 TC_ALIAS(tc_free);
 #else
@@ -1931,14 +1931,14 @@ TC_ALIAS(tc_free);
 #endif
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_memalign(size_t align,
-                                                size_t size) PERFTOOLS_THROW {
+                                                size_t size) PERFTOOLS_NOTHROW {
   void* result = do_memalign_or_cpp_memalign(align, size);
   MallocHook::InvokeNewHook(result, size);
   return result;
 }
 
 extern "C" PERFTOOLS_DLL_DECL int tc_posix_memalign(
-    void** result_ptr, size_t align, size_t size) PERFTOOLS_THROW {
+    void** result_ptr, size_t align, size_t size) PERFTOOLS_NOTHROW {
   if (((align % sizeof(void*)) != 0) ||
       ((align & (align - 1)) != 0) ||
       (align == 0)) {
@@ -1957,7 +1957,7 @@ extern "C" PERFTOOLS_DLL_DECL int tc_posix_memalign(
 
 static size_t pagesize = 0;
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_valloc(size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_valloc(size_t size) PERFTOOLS_NOTHROW {
   // Allocate page-aligned object of length >= size bytes
   if (pagesize == 0) pagesize = getpagesize();
   void* result = do_memalign_or_cpp_memalign(pagesize, size);
@@ -1965,7 +1965,7 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_valloc(size_t size) PERFTOOLS_THROW {
   return result;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_NOTHROW {
   // Round up size to a multiple of pagesize
   if (pagesize == 0) pagesize = getpagesize();
   if (size == 0) {     // pvalloc(0) should allocate one page, according to
@@ -1977,25 +1977,25 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_THROW {
   return result;
 }
 
-extern "C" PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_NOTHROW {
   do_malloc_stats();
 }
 
-extern "C" PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW {
   return do_mallopt(cmd, value);
 }
 
 #ifdef HAVE_STRUCT_MALLINFO
-extern "C" PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW {
   return do_mallinfo();
 }
 #endif
 
-extern "C" PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_NOTHROW {
   return MallocExtension::instance()->GetAllocatedSize(ptr);
 }
 
-extern "C" PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size)  PERFTOOLS_THROW {
+extern "C" PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size)  PERFTOOLS_NOTHROW {
   void* result = do_malloc(size);
   MallocHook::InvokeNewHook(result, size);
   return result;

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -90,8 +90,10 @@
 #include "config.h"
 // At least for gcc on Linux/i386 and Linux/amd64 not adding throw()
 // to tc_xxx functions actually ends up generating better code.
-#ifdef __GNUC__
-#define PERFTOOLS_NOTHROW
+#if !(__cpp_noexcept_function_type >= 201510)
+# ifdef __GNUC__
+#   define PERFTOOLS_NOTHROW
+# endif
 #endif
 #include <gperftools/tcmalloc.h>
 

--- a/src/tests/tcmalloc_unittest.cc
+++ b/src/tests/tcmalloc_unittest.cc
@@ -627,7 +627,7 @@ static void TestRealloc() {
 #endif
 }
 
-static void TestNewHandler() throw (std::bad_alloc) {
+static void TestNewHandler() PERFTOOLS_THROW(std::bad_alloc) {
   ++news_handled;
   throw std::bad_alloc();
 }

--- a/src/windows/get_mangled_names.cc
+++ b/src/windows/get_mangled_names.cc
@@ -55,11 +55,11 @@
 static char m;   // some dummy memory so new doesn't return NULL.
 
 void* operator new(size_t size) { return &m; }
-void operator delete(void* p) throw() { }
+void operator delete(void* p) PERFTOOLS_NOTHROW { }
 void* operator new[](size_t size) { return &m; }
-void operator delete[](void* p) throw() { }
+void operator delete[](void* p) PERFTOOLS_NOTHROW { }
 
-void* operator new(size_t size, const std::nothrow_t&) throw() { return &m; }
-void operator delete(void* p, const std::nothrow_t&) throw() { }
-void* operator new[](size_t size, const std::nothrow_t&) throw() { return &m; }
-void operator delete[](void* p, const std::nothrow_t&) throw() { }
+void* operator new(size_t size, const std::nothrow_t&) PERFTOOLS_NOTHROW { return &m; }
+void operator delete(void* p, const std::nothrow_t&) PERFTOOLS_NOTHROW { }
+void* operator new[](size_t size, const std::nothrow_t&) PERFTOOLS_NOTHROW { return &m; }
+void operator delete[](void* p, const std::nothrow_t&) PERFTOOLS_NOTHROW { }

--- a/src/windows/gperftools/tcmalloc.h
+++ b/src/windows/gperftools/tcmalloc.h
@@ -44,17 +44,17 @@
 #define TC_VERSION_PATCH  ".93"
 #define TC_VERSION_STRING "gperftools 2.5.93"
 
-#ifndef PERFTOOLS_THROW
+#ifndef PERFTOOLS_NOTHROW
 
 #if __cplusplus >= 201103L
-#define PERFTOOLS_THROW noexcept
+#define PERFTOOLS_NOTHROW noexcept
 #elif defined(__cplusplus)
-#define PERFTOOLS_THROW throw()
+#define PERFTOOLS_NOTHROW throw()
 #else
 # ifdef __GNUC__
-#  define PERFTOOLS_THROW __attribute__((__nothrow__))
+#  define PERFTOOLS_NOTHROW __attribute__((__nothrow__))
 # else
-#  define PERFTOOLS_THROW
+#  define PERFTOOLS_NOTHROW
 # endif
 #endif
 
@@ -81,25 +81,25 @@ extern "C" {
    * minor version, and patch-code (a string, usually "").
    */
   PERFTOOLS_DLL_DECL const char* tc_version(int* major, int* minor,
-                                            const char** patch) PERFTOOLS_THROW;
+                                            const char** patch) PERFTOOLS_NOTHROW;
 
-  PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_NOTHROW;
 
   PERFTOOLS_DLL_DECL void* tc_memalign(size_t __alignment,
-                                       size_t __size) PERFTOOLS_THROW;
+                                       size_t __size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL int tc_posix_memalign(void** ptr,
-                                           size_t align, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_valloc(size_t __size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t __size) PERFTOOLS_THROW;
+                                           size_t align, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_valloc(size_t __size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t __size) PERFTOOLS_NOTHROW;
 
-  PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW;
 
   /*
    * This is an alias for MallocExtension::instance()->GetAllocatedSize().
@@ -108,31 +108,31 @@ extern "C" {
    *    glibc: malloc_usable_size()
    *    Windows: _msize()
    */
-  PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_NOTHROW;
 
 #ifdef __cplusplus
-  PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void* tc_new(size_t size);
   PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size,
-                                          const std::nothrow_t&) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_THROW;
+                                          const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p,
-                                            const std::nothrow_t&) PERFTOOLS_THROW;
+                                            const std::nothrow_t&) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void* tc_newarray(size_t size);
   PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size,
-                                               const std::nothrow_t&) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_THROW;
+                                               const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
-                                                 const std::nothrow_t&) PERFTOOLS_THROW;
+                                                 const std::nothrow_t&) PERFTOOLS_NOTHROW;
 }
 #endif
 
 /* We're only un-defining for public */
 #if !defined(GPERFTOOLS_CONFIG_H_)
 
-#undef PERFTOOLS_THROW
+#undef PERFTOOLS_NOTHROW
 
 #endif /* GPERFTOOLS_CONFIG_H_ */
 

--- a/src/windows/gperftools/tcmalloc.h.in
+++ b/src/windows/gperftools/tcmalloc.h.in
@@ -44,17 +44,17 @@
 #define TC_VERSION_PATCH  "@TC_VERSION_PATCH@"
 #define TC_VERSION_STRING "gperftools @TC_VERSION_MAJOR@.@TC_VERSION_MINOR@@TC_VERSION_PATCH@"
 
-#ifndef PERFTOOLS_THROW
+#ifndef PERFTOOLS_NOTHROW
 
 #if __cplusplus >= 201103L
-#define PERFTOOLS_THROW noexcept
+#define PERFTOOLS_NOTHROW noexcept
 #elif defined(__cplusplus)
-#define PERFTOOLS_THROW throw()
+#define PERFTOOLS_NOTHROW throw()
 #else
 # ifdef __GNUC__
-#  define PERFTOOLS_THROW __attribute__((__nothrow__))
+#  define PERFTOOLS_NOTHROW __attribute__((__nothrow__))
 # else
-#  define PERFTOOLS_THROW
+#  define PERFTOOLS_NOTHROW
 # endif
 #endif
 
@@ -81,25 +81,25 @@ extern "C" {
    * minor version, and patch-code (a string, usually "").
    */
   PERFTOOLS_DLL_DECL const char* tc_version(int* major, int* minor,
-                                            const char** patch) PERFTOOLS_THROW;
+                                            const char** patch) PERFTOOLS_NOTHROW;
 
-  PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL void* tc_malloc(size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_malloc_skip_new_handler(size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_free(void* ptr) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_free_sized(void *ptr, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_realloc(void* ptr, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_calloc(size_t nmemb, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_cfree(void* ptr) PERFTOOLS_NOTHROW;
 
   PERFTOOLS_DLL_DECL void* tc_memalign(size_t __alignment,
-                                       size_t __size) PERFTOOLS_THROW;
+                                       size_t __size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL int tc_posix_memalign(void** ptr,
-                                           size_t align, size_t size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_valloc(size_t __size) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t __size) PERFTOOLS_THROW;
+                                           size_t align, size_t size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_valloc(size_t __size) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t __size) PERFTOOLS_NOTHROW;
 
-  PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW;
 
   /*
    * This is an alias for MallocExtension::instance()->GetAllocatedSize().
@@ -108,31 +108,31 @@ extern "C" {
    *    glibc: malloc_usable_size()
    *    Windows: _msize()
    */
-  PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL size_t tc_malloc_size(void* ptr) PERFTOOLS_NOTHROW;
 
 #ifdef __cplusplus
-  PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_THROW;
+  PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void* tc_new(size_t size);
   PERFTOOLS_DLL_DECL void* tc_new_nothrow(size_t size,
-                                          const std::nothrow_t&) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_THROW;
+                                          const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete(void* p) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_delete_nothrow(void* p,
-                                            const std::nothrow_t&) PERFTOOLS_THROW;
+                                            const std::nothrow_t&) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void* tc_newarray(size_t size);
   PERFTOOLS_DLL_DECL void* tc_newarray_nothrow(size_t size,
-                                               const std::nothrow_t&) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_THROW;
-  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_THROW;
+                                               const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray(void* p) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
-                                                 const std::nothrow_t&) PERFTOOLS_THROW;
+                                                 const std::nothrow_t&) PERFTOOLS_NOTHROW;
 }
 #endif
 
 /* We're only un-defining for public */
 #if !defined(GPERFTOOLS_CONFIG_H_)
 
-#undef PERFTOOLS_THROW
+#undef PERFTOOLS_NOTHROW
 
 #endif /* GPERFTOOLS_CONFIG_H_ */
 


### PR DESCRIPTION
Hi,

C++17 deprecated the usage of "throw(std::bad_alloc)" which causes error when building with gcc 7 and -std=gnu++17.

Here is a small patch set to fix that:
 - Rename PERFTOOLS_THROW into PERFTOOLS_NOTHROW (less counter intuitive name)
 - Add PERFTOOLS_THROW where necessary (as detected by GCC)
 - Replace "throw()" by "PERFTOOLS_NOTHROW" (not necessary, but I find it cleaner to always use the same syntax IMO).

Cheers,
Romain