### PR TITLE
Use ucontext_t instead of struct ucontext

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -162,6 +162,7 @@ extern "C" {
 #include <unistd.h>
 #include <linux/unistd.h>
 #include <endian.h>
+#include <fcntl.h>
 
 #ifdef __mips__
 /* Include definitions of the ABI currently in use.                          */

--- a/src/stacktrace_powerpc-linux-inl.h
+++ b/src/stacktrace_powerpc-linux-inl.h
@@ -53,7 +53,6 @@
 #elif defined(HAVE_UCONTEXT_H)
 #include <ucontext.h>  // for ucontext_t
 #endif
-typedef ucontext ucontext_t;
 
 // PowerPC64 Little Endian follows BE wrt. backchain, condition register,
 // and LR save area, so no need to adjust the reading struct.
@@ -202,7 +201,7 @@ static int GET_STACK_TRACE_OR_FRAMES {
         struct rt_signal_frame_32 {
           char dummy[64 + 16];
           siginfo_t info;
-          struct ucontext uc;
+          ucontext_t uc;
           // We don't care about the rest, since IP value is at 'uc' field.A
         } *sigframe = reinterpret_cast<rt_signal_frame_32*>(current);
         result[n] = (void*) sigframe->uc.uc_mcontext.uc_regs->gregs[PT_NIP];


### PR DESCRIPTION
Newer glibc has dropped the ucontext tag from exposing

Signed-off-by: Khem Raj <raj.khem@gmail.com>