### PR TITLE
Some minor bug fix

### DIFF
--- a/src/debugallocation.cc
+++ b/src/debugallocation.cc
@@ -889,6 +889,7 @@ static void TracePrintf(int fd, const char *fmt, ...) {
   const char *p = fmt;
   char numbuf[25];
   if (fd < 0) {
+    va_end(ap);
     return;
   }
   numbuf[sizeof(numbuf)-1] = 0;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -238,6 +238,7 @@ int SymbolTable::Symbolize() {
       }
       write(child_in[1], pprof_buffer, strlen(pprof_buffer));
       close(child_in[1]);             // that's all we need to write
+      delete[] pprof_buffer;
 
       const int kSymbolBufferSize = kSymbolSize * symbolization_table_.size();
       int total_bytes_read = 0;


### PR DESCRIPTION
1. va_end() missing - src/symbolize.cc - SymbolTable::Symbolize
2. memory leak - src/debugallocation.cc - TracePrintf
