### PR TITLE
Fixed LTO warning for return values for ProfilingIsEnabledForAllThreads

### DIFF
--- a/src/heap-checker.cc
+++ b/src/heap-checker.cc
@@ -131,8 +131,8 @@ static bool IsDebuggerAttached(void) {    // only works under linux, probably
 
 // This is the default if you don't link in -lprofiler
 extern "C" {
-ATTRIBUTE_WEAK PERFTOOLS_DLL_DECL bool ProfilingIsEnabledForAllThreads();
-bool ProfilingIsEnabledForAllThreads() { return false; }
+ATTRIBUTE_WEAK PERFTOOLS_DLL_DECL int ProfilingIsEnabledForAllThreads();
+int ProfilingIsEnabledForAllThreads() { return false; }
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Fixed LTO warning about the mismatch between return values for ProfilingIsEnabledForAllThreads().

When compiled with -flto and linking against a library compiled as such I get a warning about mismatched return type. Attached is the fix.