### PR TITLE
Add support for C++17 operator new/delete for overaligned types

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,9 @@ endif HAVE_W_NO_UNUSED_RESULT
 if HAVE_SIZED_DEALLOCATION
 AM_CXXFLAGS += -fsized-deallocation
 endif HAVE_SIZED_DEALLOCATION
+if HAVE_F_ALIGNED_NEW
+AM_CXXFLAGS += -faligned-new
+endif HAVE_F_ALIGNED_NEW
 
 # The -no-undefined flag allows libtool to generate shared libraries for
 # Cygwin and MinGW.  LIBSTDCXX_LA_LINKER_FLAG is used to fix a Solaris bug.

--- a/configure.ac
+++ b/configure.ac
@@ -382,6 +382,44 @@ AC_CACHE_CHECK([if C++ compiler supports -fsized-deallocation],
 AM_CONDITIONAL(HAVE_SIZED_DEALLOCATION,
                test "$perftools_cv_sized_deallocation_result" = yes)
 
+AC_CACHE_CHECK([if C++ compiler supports std::align_val_t without options],
+               [perftools_cv_have_align_val_t],
+               [AC_LANG_PUSH(C++)
+                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                    [[#include <new>]],
+                    [[(::operator delete)((::operator new)(256, std::align_val_t(16)), std::align_val_t(16))]])],
+                 perftools_cv_have_align_val_t=yes,
+                 perftools_cv_have_align_val_t=no)
+                AC_LANG_POP(C++)])
+
+AC_CACHE_CHECK([if C++ compiler supports -faligned-new],
+               [perftools_cv_have_f_aligned_new],
+               [AC_LANG_PUSH(C++)
+                OLD_CXXFLAGS="$CXXFLAGS"
+                CXXFLAGS="$CXXFLAGS -faligned-new"
+                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                    [[#include <new>]],
+                    [[(::operator delete)((::operator new)(256, std::align_val_t(16)), std::align_val_t(16))]])],
+                 perftools_cv_have_f_aligned_new=yes,
+                 perftools_cv_have_f_aligned_new=no)
+                CXXFLAGS="$OLD_CXXFLAGS"
+                AC_LANG_POP(C++)])
+
+AM_CONDITIONAL(HAVE_F_ALIGNED_NEW,
+               test "$perftools_cv_have_f_aligned_new" = yes)
+
+AS_IF([test "$perftools_cv_have_align_val_t" = yes || test "$perftools_cv_have_f_aligned_new" = yes],
+        [AC_DEFINE([ENABLE_ALIGNED_NEW_DELETE], 1, [Build new/delete operators for overaligned types])
+         AC_MSG_NOTICE([Will build new/delete operators for overaligned types])],
+         AC_MSG_NOTICE([Will not build new/delete operators for overaligned types]))
+
+if test "$perftools_cv_have_align_val_t" = yes || test "$perftools_cv_have_f_aligned_new" = yes; then
+  AC_SUBST(ac_cv_have_std_align_val_t, 1)   # gperftools/tcmalloc.h and windows/gperftools/tcmalloc.h need this
+else
+  AC_SUBST(ac_cv_have_std_align_val_t, 0)
+fi
+
+
 AC_CACHE_CHECK([if target has _Unwind_Backtrace],
                [perftools_cv_have_unwind_backtrace],
                [AC_LANG_PUSH(C++)

--- a/src/debugallocation.cc
+++ b/src/debugallocation.cc
@@ -97,6 +97,10 @@
 # define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#if defined(__GNUC__) && defined(__ELF__) && !defined(TCMALLOC_NO_ALIASES) && !defined(TC_ALIAS)
+#define TC_ALIAS(name) __attribute__((alias(#name)))
+#endif
+
 // ========================================================================= //
 
 DEFINE_bool(malloctrace,
@@ -417,6 +421,7 @@ class MallocBlock {
     alloc_map_lock_.Unlock();
     // clear us
     const size_t size = real_size();
+
     RAW_CHECK(!given_size || given_size == size1_,
               "right size must be passed to sized delete");
     memset(this, kMagicDeletedByte, size);
@@ -1388,7 +1393,7 @@ extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p, const std::no
 }
 
 // This is mostly the same as do_memalign in tcmalloc.cc.
-static void *do_debug_memalign(size_t alignment, size_t size) {
+static void *do_debug_memalign(size_t alignment, size_t size, int type) {
   // Allocate >= size bytes aligned on "alignment" boundary
   // "alignment" is a power of two.
   void *p = 0;
@@ -1398,7 +1403,7 @@ static void *do_debug_memalign(size_t alignment, size_t size) {
   // a further data_offset bytes for an additional fake header.
   size_t extra_bytes = data_offset + alignment - 1;
   if (size + extra_bytes < size) return NULL;         // Overflow
-  p = DebugAllocate(size + extra_bytes, MallocBlock::kMallocType);
+  p = DebugAllocate(size + extra_bytes, type);
   if (p != 0) {
     intptr_t orig_p = reinterpret_cast<intptr_t>(p);
     // Leave data_offset bytes for fake header, and round up to meet
@@ -1423,16 +1428,21 @@ static void *do_debug_memalign(size_t alignment, size_t size) {
 struct memalign_retry_data {
   size_t align;
   size_t size;
+  int type;
 };
 
 static void *retry_debug_memalign(void *arg) {
   memalign_retry_data *data = static_cast<memalign_retry_data *>(arg);
-  return do_debug_memalign(data->align, data->size);
+  return do_debug_memalign(data->align, data->size, data->type);
 }
 
+ATTRIBUTE_ALWAYS_INLINE
 inline void* do_debug_memalign_or_debug_cpp_memalign(size_t align,
-                                                     size_t size) {
-  void* p = do_debug_memalign(align, size);
+                                                     size_t size,
+                                                     int type,
+                                                     bool from_operator,
+                                                     bool nothrow) {
+  void* p = do_debug_memalign(align, size, type);
   if (p != NULL) {
     return p;
   }
@@ -1440,12 +1450,13 @@ inline void* do_debug_memalign_or_debug_cpp_memalign(size_t align,
   struct memalign_retry_data data;
   data.align = align;
   data.size = size;
+  data.type = type;
   return handle_oom(retry_debug_memalign, &data,
-                    false, true);
+                    from_operator, nothrow);
 }
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_memalign(size_t align, size_t size) PERFTOOLS_NOTHROW {
-  void *p = do_debug_memalign_or_debug_cpp_memalign(align, size);
+  void *p = do_debug_memalign_or_debug_cpp_memalign(align, size, MallocBlock::kMallocType, false, true);
   MallocHook::InvokeNewHook(p, size);
   return p;
 }
@@ -1459,7 +1470,7 @@ extern "C" PERFTOOLS_DLL_DECL int tc_posix_memalign(void** result_ptr, size_t al
     return EINVAL;
   }
 
-  void* result = do_debug_memalign_or_debug_cpp_memalign(align, size);
+  void* result = do_debug_memalign_or_debug_cpp_memalign(align, size, MallocBlock::kMallocType, false, true);
   MallocHook::InvokeNewHook(result, size);
   if (result == NULL) {
     return ENOMEM;
@@ -1471,7 +1482,7 @@ extern "C" PERFTOOLS_DLL_DECL int tc_posix_memalign(void** result_ptr, size_t al
 
 extern "C" PERFTOOLS_DLL_DECL void* tc_valloc(size_t size) PERFTOOLS_NOTHROW {
   // Allocate >= size bytes starting on a page boundary
-  void *p = do_debug_memalign_or_debug_cpp_memalign(getpagesize(), size);
+  void *p = do_debug_memalign_or_debug_cpp_memalign(getpagesize(), size, MallocBlock::kMallocType, false, true);
   MallocHook::InvokeNewHook(p, size);
   return p;
 }
@@ -1484,10 +1495,72 @@ extern "C" PERFTOOLS_DLL_DECL void* tc_pvalloc(size_t size) PERFTOOLS_NOTHROW {
   if (size == 0) {     // pvalloc(0) should allocate one page, according to
     size = pagesize;   // http://man.free4web.biz/man3/libmpatrol.3.html
   }
-  void *p = do_debug_memalign_or_debug_cpp_memalign(pagesize, size);
+  void *p = do_debug_memalign_or_debug_cpp_memalign(pagesize, size, MallocBlock::kMallocType, false, true);
   MallocHook::InvokeNewHook(p, size);
   return p;
 }
+
+#if defined(ENABLE_ALIGNED_NEW_DELETE)
+
+extern "C" PERFTOOLS_DLL_DECL void* tc_new_aligned(size_t size, std::align_val_t align) {
+  void* result = do_debug_memalign_or_debug_cpp_memalign(static_cast<size_t>(align), size, MallocBlock::kNewType, true, false);
+  MallocHook::InvokeNewHook(result, size);
+  return result;
+}
+
+extern "C" PERFTOOLS_DLL_DECL void* tc_new_aligned_nothrow(size_t size, std::align_val_t align, const std::nothrow_t&) PERFTOOLS_NOTHROW {
+  void* result = do_debug_memalign_or_debug_cpp_memalign(static_cast<size_t>(align), size, MallocBlock::kNewType, true, true);
+  MallocHook::InvokeNewHook(result, size);
+  return result;
+}
+
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_aligned(void* p, std::align_val_t) PERFTOOLS_NOTHROW {
+  tc_delete(p);
+}
+
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_sized_aligned(void* p, size_t size, std::align_val_t align) PERFTOOLS_NOTHROW {
+  // Reproduce actual size calculation done by do_debug_memalign
+  const size_t alignment = static_cast<size_t>(align);
+  const size_t data_offset = MallocBlock::data_offset();
+  const size_t extra_bytes = data_offset + alignment - 1;
+
+  tc_delete_sized(p, size + extra_bytes);
+}
+
+extern "C" PERFTOOLS_DLL_DECL void tc_delete_aligned_nothrow(void* p, std::align_val_t, const std::nothrow_t&) PERFTOOLS_NOTHROW {
+  tc_delete(p);
+}
+
+extern "C" PERFTOOLS_DLL_DECL void* tc_newarray_aligned(size_t size, std::align_val_t align) {
+  void* result = do_debug_memalign_or_debug_cpp_memalign(static_cast<size_t>(align), size, MallocBlock::kArrayNewType, true, false);
+  MallocHook::InvokeNewHook(result, size);
+  return result;
+}
+
+extern "C" PERFTOOLS_DLL_DECL void* tc_newarray_aligned_nothrow(size_t size, std::align_val_t align, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
+  void* result = do_debug_memalign_or_debug_cpp_memalign(static_cast<size_t>(align), size, MallocBlock::kArrayNewType, true, true);
+  MallocHook::InvokeNewHook(result, size);
+  return result;
+}
+
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_aligned(void* p, std::align_val_t) PERFTOOLS_NOTHROW {
+  tc_deletearray(p);
+}
+
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_sized_aligned(void* p, size_t size, std::align_val_t align) PERFTOOLS_NOTHROW {
+  // Reproduce actual size calculation done by do_debug_memalign
+  const size_t alignment = static_cast<size_t>(align);
+  const size_t data_offset = MallocBlock::data_offset();
+  const size_t extra_bytes = data_offset + alignment - 1;
+
+  tc_deletearray_sized(p, size + extra_bytes);
+}
+
+extern "C" PERFTOOLS_DLL_DECL void tc_deletearray_aligned_nothrow(void* p, std::align_val_t, const std::nothrow_t&) PERFTOOLS_NOTHROW {
+  tc_deletearray(p);
+}
+
+#endif // defined(ENABLE_ALIGNED_NEW_DELETE)
 
 // malloc_stats just falls through to the base implementation.
 extern "C" PERFTOOLS_DLL_DECL void tc_malloc_stats(void) PERFTOOLS_NOTHROW {

--- a/src/gperftools/tcmalloc.h.in
+++ b/src/gperftools/tcmalloc.h.in
@@ -37,6 +37,9 @@
 #define TCMALLOC_TCMALLOC_H_
 
 #include <stddef.h>                     /* for size_t */
+#ifdef __cplusplus
+#include <new>                          /* for std::nothrow_t, std::align_val_t */
+#endif
 
 /* Define the version number so folks can check against it */
 #define TC_VERSION_MAJOR  @TC_VERSION_MAJOR@
@@ -74,10 +77,6 @@
 #endif
 
 #ifdef __cplusplus
-namespace std {
-struct nothrow_t;
-}
-
 extern "C" {
 #endif
   /*
@@ -134,6 +133,23 @@ extern "C" {
   PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
                                                  const std::nothrow_t&) PERFTOOLS_NOTHROW;
+
+#if @ac_cv_have_std_align_val_t@ && __cplusplus >= 201703L
+  PERFTOOLS_DLL_DECL void* tc_new_aligned(size_t size, std::align_val_t al);
+  PERFTOOLS_DLL_DECL void* tc_new_aligned_nothrow(size_t size, std::align_val_t al,
+                                          const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_aligned(void* p, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized_aligned(void* p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_aligned_nothrow(void* p, std::align_val_t al,
+                                            const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_newarray_aligned(size_t size, std::align_val_t al);
+  PERFTOOLS_DLL_DECL void* tc_newarray_aligned_nothrow(size_t size, std::align_val_t al,
+                                               const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_aligned(void* p, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized_aligned(void* p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_aligned_nothrow(void* p, std::align_val_t al,
+                                                 const std::nothrow_t&) PERFTOOLS_NOTHROW;
+#endif
 }
 #endif
 

--- a/src/libc_override_gcc_and_weak.h
+++ b/src/libc_override_gcc_and_weak.h
@@ -136,6 +136,81 @@ void operator delete[](void *p, size_t size) PERFTOOLS_NOTHROW
 
 #endif /* !ENABLE_SIZED_DELETE && !ENABLE_DYN_SIZED_DELETE */
 
+#if defined(ENABLE_ALIGNED_NEW_DELETE)
+
+void* operator new(size_t size, std::align_val_t al) PERFTOOLS_THROW(std::bad_alloc)
+    ALIAS(tc_new_aligned);
+void operator delete(void* p, std::align_val_t al) PERFTOOLS_NOTHROW
+    ALIAS(tc_delete_aligned);
+void* operator new[](size_t size, std::align_val_t al) PERFTOOLS_THROW(std::bad_alloc)
+    ALIAS(tc_newarray_aligned);
+void operator delete[](void* p, std::align_val_t al) PERFTOOLS_NOTHROW
+    ALIAS(tc_deletearray_aligned);
+void* operator new(size_t size, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
+    ALIAS(tc_new_aligned_nothrow);
+void* operator new[](size_t size, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
+    ALIAS(tc_newarray_aligned_nothrow);
+void operator delete(void* p, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
+    ALIAS(tc_delete_aligned_nothrow);
+void operator delete[](void* p, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW
+    ALIAS(tc_deletearray_aligned_nothrow);
+
+#if defined(ENABLE_SIZED_DELETE)
+
+void operator delete(void *p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW
+    ALIAS(tc_delete_sized_aligned);
+void operator delete[](void *p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW
+    ALIAS(tc_deletearray_sized_aligned);
+
+#else /* defined(ENABLE_SIZED_DELETE) */
+
+static void delegate_sized_aligned_delete(void *p, size_t s, std::align_val_t al) PERFTOOLS_NOTHROW {
+  (operator delete)(p, al);
+}
+
+static void delegate_sized_aligned_deletearray(void *p, size_t s, std::align_val_t al) PERFTOOLS_NOTHROW {
+  (operator delete[])(p, al);
+}
+
+#if defined(ENABLE_DYNAMIC_SIZED_DELETE) && \
+  (__GNUC__ * 100 + __GNUC_MINOR__) >= 405
+
+extern "C" {
+
+static void *resolve_delete_sized_aligned(void) {
+  if (sized_delete_enabled()) {
+    return reinterpret_cast<void *>(tc_delete_sized_aligned);
+  }
+  return reinterpret_cast<void *>(delegate_sized_aligned_delete);
+}
+
+static void *resolve_deletearray_sized_aligned(void) {
+  if (sized_delete_enabled()) {
+    return reinterpret_cast<void *>(tc_deletearray_sized_aligned);
+  }
+  return reinterpret_cast<void *>(delegate_sized_aligned_deletearray);
+}
+
+}
+
+void operator delete(void *p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW
+  __attribute__((ifunc("resolve_delete_sized_aligned")));
+void operator delete[](void *p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW
+  __attribute__((ifunc("resolve_deletearray_sized_aligned")));
+
+#else /* defined(ENABLE_DYN_SIZED_DELETE) */
+
+void operator delete(void *p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW
+  ALIAS(tc_delete);
+void operator delete[](void *p, size_t size) PERFTOOLS_NOTHROW
+  ALIAS(tc_deletearray);
+
+#endif /* defined(ENABLE_DYN_SIZED_DELETE) */
+
+#endif /* defined(ENABLE_SIZED_DELETE) */
+
+#endif /* defined(ENABLE_ALIGNED_NEW_DELETE) */
+
 extern "C" {
   void* malloc(size_t size) __THROW               ALIAS(tc_malloc);
   void free(void* ptr) __THROW                    ALIAS(tc_free);

--- a/src/libc_override_redefine.h
+++ b/src/libc_override_redefine.h
@@ -61,8 +61,46 @@ void operator delete[](void* ptr, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
 
 #ifdef ENABLE_SIZED_DELETE
 void operator delete(void* p, size_t s) PERFTOOLS_NOTHROW  { tc_delete_sized(p, s);     }
-void operator delete[](void* p, size_t s) PERFTOOLS_NOTHROW{ tc_deletearray_sized(p);   }
+void operator delete[](void* p, size_t s) PERFTOOLS_NOTHROW{ tc_deletearray_sized(p, s); }
 #endif
+
+#if defined(ENABLE_ALIGNED_NEW_DELETE)
+
+void* operator new(size_t size, std::align_val_t al) {
+  return tc_new_aligned(size, al);
+}
+void operator delete(void* p, std::align_val_t al) PERFTOOLS_NOTHROW {
+  tc_delete_aligned(p, al);
+}
+void* operator new[](size_t size, std::align_val_t al) {
+  return tc_newarray_aligned(size, al);
+}
+void operator delete[](void* p, std::align_val_t al) PERFTOOLS_NOTHROW {
+  tc_deletearray_aligned(p, al);
+}
+void* operator new(size_t size, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
+  return tc_new_aligned_nothrow(size, al, nt);
+}
+void* operator new[](size_t size, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
+  return tc_newarray_aligned_nothrow(size, al, nt);
+}
+void operator delete(void* ptr, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
+  return tc_delete_aligned_nothrow(ptr, al, nt);
+}
+void operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t& nt) PERFTOOLS_NOTHROW {
+  return tc_deletearray_aligned_nothrow(ptr, al, nt);
+}
+
+#ifdef ENABLE_SIZED_DELETE
+void operator delete(void* p, size_t s, std::align_val_t al) PERFTOOLS_NOTHROW {
+  tc_delete_sized_aligned(p, s, al);
+}
+void operator delete[](void* p, size_t s, std::align_val_t al) PERFTOOLS_NOTHROW {
+  tc_deletearray_sized_aligned(p, s, al);
+}
+#endif
+
+#endif // defined(ENABLE_ALIGNED_NEW_DELETE)
 
 extern "C" {
   void* malloc(size_t s)                         { return tc_malloc(s);       }

--- a/src/windows/gperftools/tcmalloc.h
+++ b/src/windows/gperftools/tcmalloc.h
@@ -37,6 +37,9 @@
 #define TCMALLOC_TCMALLOC_H_
 
 #include <stddef.h>                     /* for size_t */
+#ifdef __cplusplus
+#include <new>                          /* for std::nothrow_t, std::align_val_t */
+#endif
 
 /* Define the version number so folks can check against it */
 #define TC_VERSION_MAJOR  2
@@ -69,10 +72,6 @@
 #endif
 
 #ifdef __cplusplus
-namespace std {
-struct nothrow_t;
-}
-
 extern "C" {
 #endif
   /*
@@ -126,6 +125,23 @@ extern "C" {
   PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
                                                  const std::nothrow_t&) PERFTOOLS_NOTHROW;
+
+#if 1 && __cplusplus >= 201703L
+  PERFTOOLS_DLL_DECL void* tc_new_aligned(size_t size, std::align_val_t al);
+  PERFTOOLS_DLL_DECL void* tc_new_aligned_nothrow(size_t size, std::align_val_t al,
+                                          const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_aligned(void* p, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized_aligned(void* p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_aligned_nothrow(void* p, std::align_val_t al,
+                                            const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_newarray_aligned(size_t size, std::align_val_t al);
+  PERFTOOLS_DLL_DECL void* tc_newarray_aligned_nothrow(size_t size, std::align_val_t al,
+                                               const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_aligned(void* p, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized_aligned(void* p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_aligned_nothrow(void* p, std::align_val_t al,
+                                                 const std::nothrow_t&) PERFTOOLS_NOTHROW;
+#endif
 }
 #endif
 

--- a/src/windows/gperftools/tcmalloc.h.in
+++ b/src/windows/gperftools/tcmalloc.h.in
@@ -37,6 +37,9 @@
 #define TCMALLOC_TCMALLOC_H_
 
 #include <stddef.h>                     /* for size_t */
+#ifdef __cplusplus
+#include <new>                          /* for std::nothrow_t, std::align_val_t */
+#endif
 
 /* Define the version number so folks can check against it */
 #define TC_VERSION_MAJOR  @TC_VERSION_MAJOR@
@@ -69,10 +72,6 @@
 #endif
 
 #ifdef __cplusplus
-namespace std {
-struct nothrow_t;
-}
-
 extern "C" {
 #endif
   /*
@@ -126,6 +125,23 @@ extern "C" {
   PERFTOOLS_DLL_DECL void tc_deletearray_sized(void* p, size_t size) PERFTOOLS_NOTHROW;
   PERFTOOLS_DLL_DECL void tc_deletearray_nothrow(void* p,
                                                  const std::nothrow_t&) PERFTOOLS_NOTHROW;
+
+#if @ac_cv_have_std_align_val_t@ && __cplusplus >= 201703L
+  PERFTOOLS_DLL_DECL void* tc_new_aligned(size_t size, std::align_val_t al);
+  PERFTOOLS_DLL_DECL void* tc_new_aligned_nothrow(size_t size, std::align_val_t al,
+                                          const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_aligned(void* p, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_sized_aligned(void* p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_delete_aligned_nothrow(void* p, std::align_val_t al,
+                                            const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void* tc_newarray_aligned(size_t size, std::align_val_t al);
+  PERFTOOLS_DLL_DECL void* tc_newarray_aligned_nothrow(size_t size, std::align_val_t al,
+                                               const std::nothrow_t&) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_aligned(void* p, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_sized_aligned(void* p, size_t size, std::align_val_t al) PERFTOOLS_NOTHROW;
+  PERFTOOLS_DLL_DECL void tc_deletearray_aligned_nothrow(void* p, std::align_val_t al,
+                                                 const std::nothrow_t&) PERFTOOLS_NOTHROW;
+#endif
 }
 #endif
 


### PR DESCRIPTION
- Add auto-detection of `std::align_val_t` presence to configure scripts. This
  indicates that the compiler supports C++17 operator new/delete overloads
  for overaligned types.

- Add auto-detection of `-faligned-new` compiler option that appeared in gcc 7.
  The option allows the compiler to generate calls to the new operators. It is
  needed for tests.

- Added overrides for the new operators. The overrides are enabled if the
  support for `std::align_val_t` has been detected. The implementation is mostly
  based on the infrastructure used by `memalign`, which had to be extended to
  support being used by C++ operators in addition to C functions. In particular,
  the debug version of the library has to distinguish memory allocated by
  `memalign` from that by `operator new`. The current implementation of sized
  overaligned `delete` operators do not make use of the supplied size argument
  except for the debug allocator because it is difficult to calculate the exact
  allocation size that was used to allocate memory with alignment. This can be
  done in the future.

- Removed forward declaration of `std::nothrow_t`. This was not portable as
  the standard library is not required to provide `nothrow_t` directly in
  `namespace std` (it could use e.g. an inline namespace within `std`). The `<new>`
  header needs to be included for `std::align_val_t` anyway.

- Fixed `operator delete[]` implementation in `libc_override_redefine.h`.

- Moved `TC_ALIAS` definition to the beginning of the file in `tcmalloc.cc` so that
  the macro is defined before its first use in `nallocx`.

- Added tests to verify the added operators.

I only tested this on Linux with gcc 7.

The relevant C++17 proposal is [P0035R4](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0035r4.html).
