### PR TITLE
configure.ac: better test for -faligned-new

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,7 +385,7 @@ AM_CONDITIONAL(HAVE_SIZED_DEALLOCATION,
 AC_CACHE_CHECK([if C++ compiler supports std::align_val_t without options],
                [perftools_cv_have_align_val_t],
                [AC_LANG_PUSH(C++)
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                AC_LINK_IFELSE([AC_LANG_PROGRAM(
                     [[#include <new>]],
                     [[(::operator delete)((::operator new)(256, std::align_val_t(16)), std::align_val_t(16))]])],
                  perftools_cv_have_align_val_t=yes,

--- a/configure.ac
+++ b/configure.ac
@@ -397,7 +397,7 @@ AC_CACHE_CHECK([if C++ compiler supports -faligned-new],
                [AC_LANG_PUSH(C++)
                 OLD_CXXFLAGS="$CXXFLAGS"
                 CXXFLAGS="$CXXFLAGS -faligned-new"
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                AC_LINK_IFELSE([AC_LANG_PROGRAM(
                     [[#include <new>]],
                     [[(::operator delete)((::operator new)(256, std::align_val_t(16)), std::align_val_t(16))]])],
                  perftools_cv_have_f_aligned_new=yes,


### PR DESCRIPTION
Apple's clang enables aligned new/delete and sized deleted when passed
the -faligned-new flag. Compilation of tcmalloc_unit fails in this case
because the aligned/sized new/delete functions were not defined and
the appropriate operators not overloaded.

Fixes #942.