### PR TITLE
Enable tcmalloc VDSO support only on x86 to reduce static initializers

### DIFF
--- a/src/base/vdso_support.h
+++ b/src/base/vdso_support.h
@@ -61,7 +61,11 @@
 
 #ifdef HAVE_ELF_MEM_IMAGE
 
+// This matches the same conditions of stacktrace_x86-inl.h, the only client of
+// vdso_support, to avoid static initializers.
+#if defined(__linux__) && defined(__i386__)
 #define HAVE_VDSO_SUPPORT 1
+#endif
 
 #include <stdlib.h>     // for NULL
 


### PR DESCRIPTION
Background context
------------------
crrev.com/1466173002 switched the GN tcmalloc target from source_set
-> static_library. There are good reasons for keeping tcmalloc a
source_set (see "Note on static libraries" in [1]).  However, in the
current state source_set was exposing extra static initializers in the
GN build which, are not present in the gyp build due to the linker gc
sections.

Resolution of this CL
---------------------
The fact that vdso_support.cc is GC-ed by the linker is the symptom
that such code is unreachable. A search in the codebase shows that the
only client is stacktrace_x86-inl.h, which depends on VDSO only when
defined(__linux__) && defined(__i386__) This CL is therefore matching
this condition in vdso_support.h and conditioning the #define
HAVE_VDSO_SUPPORT with the same conditions.

[1] https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/cookbook.md

References:
https://bugs.chromium.org/p/chromium/issues/detail?id=559766
https://bugs.chromium.org/p/chromium/issues/detail?id=564618