### PR TITLE
Don't let tcmalloc read all kinds of env vars at startup

### DIFF
--- a/src/base/commandlineflags.h
+++ b/src/base/commandlineflags.h
@@ -157,6 +157,8 @@ namespace tcmalloc {
 // These macros (could be functions, but I don't want to bother with a .cc
 // file), make it easier to initialize flags from the environment.
 
+#if defined(ENABLE_PROFILING)
+
 #define EnvToString(envname, dflt)   \
   (!getenv(envname) ? (dflt) : getenv(envname))
 
@@ -171,5 +173,15 @@ namespace tcmalloc {
 
 #define EnvToDouble(envname, dflt)  \
   tcmalloc::commandlineflags::StringToDouble(getenv(envname), dflt)
+
+#else  // defined(ENABLE_PROFILING)
+
+#define EnvToString(envname, dflt) (dflt)
+#define EnvToBool(envname, dflt) (dflt)
+#define EnvToInt(envname, dflt) (dflt)
+#define EnvToInt64(envname, dflt) (dflt)
+#define EnvToDouble(envname, dflt) (dflt)
+
+#endif  // defined(ENABLE_PROFILING)
 
 #endif  // BASE_COMMANDLINEFLAGS_H_


### PR DESCRIPTION
The env vars are still used in profiling=1 builds, by such illustrious
figures as the deep memory profiler bot and willchan. Reading from the
environment variables uses static initializers, so this change will
eliminate those static initializers in profiling=0 builds.

As discussed in the chromium-dev thread "Does anyone use tcmalloc's
debugging envvars?".

Reference:
https://bugs.chromium.org/p/chromium/issues/detail?id=94925