### PR TITLE
Add total delay metric for spinlocks

### DIFF
--- a/src/base/spinlock.cc
+++ b/src/base/spinlock.cc
@@ -49,6 +49,47 @@ const base::LinkerInitialized SpinLock::LINKER_INITIALIZED =
     base::LINKER_INITIALIZED;
 
 namespace {
+
+const int64_t kNanoPerSec = uint64_t(1000) * 1000 * 1000;
+
+#ifdef _WIN32
+int64_t frequency;
+
+void InitTimer() {
+    LARGE_INTEGER large_freq;
+    QueryPerformanceFrequency(&large_freq);
+    frequency = large_freq.QuadPart;
+}
+
+int64_t NowMonotonic() {
+  LARGE_INTEGER time_value;
+  QueryPerformanceCounter(&time_value);
+  return time_value.QuadPart;
+}
+
+int64_t TicksToNanos(int64_t timer_value) {
+  return timer_value * kNanoPerSec / frequency;
+}
+
+#else // _WIN32
+void InitTimer() {}
+
+int64_t NowMonotonic() {
+  struct timespec t;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &t)) {
+    return 0;
+  }
+
+  return (static_cast<double>(t.tv_sec) * kNanoPerSec) + t.tv_nsec;
+}
+
+int64_t TicksToNanos(int64_t timer_value) {
+  return timer_value;
+}
+
+#endif // _WIN32
+
 struct SpinLock_InitHelper {
   SpinLock_InitHelper() {
     // On multi-cpu machines, spin for longer before yielding
@@ -56,6 +97,8 @@ struct SpinLock_InitHelper {
     if (GetSystemCPUsCount() > 1) {
       adaptive_spin_count = 1000;
     }
+
+    InitTimer();
   }
 };
 
@@ -68,6 +111,31 @@ inline void SpinlockPause(void) {
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
   __asm__ __volatile__("rep; nop" : : );
 #endif
+}
+
+// The current version of atomic_ops.h lacks base::subtle::Barrier_AtomicIncrement
+// so a CAS loop is used instead.
+void NoBarrier_AtomicAdd(volatile base::subtle::Atomic64* ptr,
+                         base::subtle::Atomic64 increment) {
+  base::subtle::Atomic64 base_value = base::subtle::NoBarrier_Load(ptr);
+  while (true) {
+    base::subtle::Atomic64 new_value;
+    base::subtle::NoBarrier_Store(&new_value, base::subtle::NoBarrier_Load(&base_value)
+          + base::subtle::NoBarrier_Load(&increment));
+
+    // Swap in the new incremented value.
+    base::subtle::Atomic64 cas_result = base::subtle::Acquire_CompareAndSwap(
+          ptr, base_value, new_value);
+
+    // Check if the increment succeeded.
+    if (cas_result == base_value) {
+      return;
+    }
+
+    // If the increment failed, just use the previous value as the value to
+    // add our increment to.
+    base_value = cas_result;
+  };
 }
 
 }  // unnamed namespace
@@ -84,10 +152,13 @@ Atomic32 SpinLock::SpinLoop() {
                                               kSpinLockSleeper);
 }
 
+base::subtle::Atomic64 SpinLock::totalDelayNanos_ = 0;
+
 void SpinLock::SlowLock() {
   Atomic32 lock_value = SpinLoop();
 
   int lock_wait_call_count = 0;
+  int64_t start = 0;
   while (lock_value != kSpinLockFree) {
     // If the lock is currently held, but not marked as having a sleeper, mark
     // it as having a sleeper.
@@ -115,11 +186,17 @@ void SpinLock::SlowLock() {
     }
 
     // Wait for an OS specific delay.
+    start = NowMonotonic();
     base::internal::SpinLockDelay(&lockword_, lock_value,
                                   ++lock_wait_call_count);
     // Spin again after returning from the wait routine to give this thread
     // some chance of obtaining the lock.
     lock_value = SpinLoop();
+  }
+
+  if (start) {
+    NoBarrier_AtomicAdd(&totalDelayNanos_, static_cast<base::subtle::Atomic64>(
+        TicksToNanos(NowMonotonic() - start)));
   }
 }
 

--- a/src/base/spinlock.h
+++ b/src/base/spinlock.h
@@ -107,6 +107,10 @@ class LOCKABLE SpinLock {
     return base::subtle::NoBarrier_Load(&lockword_) != kSpinLockFree;
   }
 
+  static base::subtle::Atomic64 GetTotalDelayNanos() {
+    return base::subtle::NoBarrier_Load(&totalDelayNanos_);
+  }
+
   static const base::LinkerInitialized LINKER_INITIALIZED;  // backwards compat
  private:
   enum { kSpinLockFree = 0 };
@@ -114,6 +118,8 @@ class LOCKABLE SpinLock {
   enum { kSpinLockSleeper = 2 };
 
   volatile Atomic32 lockword_;
+
+  static base::subtle::Atomic64 totalDelayNanos_;
 
   void SlowLock();
   void SlowUnlock();

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -819,6 +819,11 @@ class TCMallocImplementation : public MallocExtension {
       return true;
     }
 
+    if (strcmp(name, "tcmalloc.spinlock_total_delay_ns") == 0) {
+      *value = SpinLock::GetTotalDelayNanos();
+      return true;
+    }
+
     return false;
   }
 


### PR DESCRIPTION
The work here is derived from changes made to the vendored copy of gperftools in MongoDB. For background on these changes, please see https://jira.mongodb.org/browse/SERVER-30114.

In our testing, we did not observe a significant performance impact from this instrumentation, as it only affects the spin lock slow path, but it is definitely a potential concern for the general case. We also had some discussion around whether the platform introspection here is sufficient - we rely on `clock_gettime` and `CLOCK_MONOTONIC` for all platforms of interest to us, but we recognize that there may be other platforms where these are not available.

We think though that on balance this diagnostic information is very useful for understanding certain types of workload issues, and we are interested in finding a way to merge it if possible.