### PR TITLE
Re-enable VDSO support for powerpc{|64|64le}

### DIFF
--- a/src/base/vdso_support.h
+++ b/src/base/vdso_support.h
@@ -61,9 +61,9 @@
 
 #ifdef HAVE_ELF_MEM_IMAGE
 
-// This matches the same conditions of stacktrace_x86-inl.h, the only client of
-// vdso_support, to avoid static initializers.
-#if defined(__linux__) && defined(__i386__)
+// Enable VDSO support only for the architectures/operating systems that
+// support it.
+#if defined(__linux__) && (defined(__i386__) || defined(__PPC__))
 #define HAVE_VDSO_SUPPORT 1
 #endif
 


### PR DESCRIPTION
This patch fix a regression in powerpc after VDSO support was disabled to all architectures except x86 (commit 36bfa9a4046109efa40ccc0806c72331de9c915b).

Tested on powerpc, powerpc64 and powerpc64le.