### PR TITLE
Fix WIN32_OVERRIDE_ALLOCATORS for VS2017

### DIFF
--- a/src/libc_override.h
+++ b/src/libc_override.h
@@ -58,7 +58,7 @@
 #endif
 #include <gperftools/tcmalloc.h>
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
 #define CPP_NOTHROW noexcept
 #define CPP_BADALLOC
 #else

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -1691,6 +1691,10 @@ extern "C" PERFTOOLS_DLL_DECL int tc_set_new_mode(int flag) PERFTOOLS_NOTHROW {
   return old_mode;
 }
 
+extern "C" PERFTOOLS_DLL_DECL int tc_query_new_mode() PERFTOOLS_NOTHROW {
+  return tc_new_mode;
+}
+
 #ifndef TCMALLOC_USING_DEBUGALLOCATION  // debugallocation.cc defines its own
 
 // CAVEAT: The code structure below ensures that MallocHook methods are always

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -340,6 +340,7 @@ inline int snprintf(char *str, size_t size, const char *format, ...) {
 }
 #endif
 
+#ifndef HAVE_INTTYPES_H
 #define PRIx64  "I64x"
 #define SCNx64  "I64x"
 #define PRId64  "I64d"
@@ -351,6 +352,7 @@ inline int snprintf(char *str, size_t size, const char *format, ...) {
 #else
 # define PRIuPTR "lu"
 # define PRIxPTR "lx"
+#endif
 #endif
 
 /* ----------------------------------- FILE IO */


### PR DESCRIPTION
I have run all unittests (except preamble_patcher_test because I can't even compile it) under x86 & x64 and all passed. But I have uninstalled VS2015 long time ago so I can't confirm whether VS2015 works. But theoretically it should work as well since both use UCRT. The changes in `windows/config.h` are irrelevant to the fix. It's just that I want to synchronize the settings with main `config.h` for better comparison and maintenance.