### PR TITLE
Use off64_t instead of __off64_t

### DIFF
--- a/src/malloc_hook_mmap_linux.h
+++ b/src/malloc_hook_mmap_linux.h
@@ -60,7 +60,7 @@
 
 static inline void* do_mmap64(void *start, size_t length,
                               int prot, int flags,
-                              int fd, __off64_t offset) __THROW {
+                              int fd, off64_t offset) __THROW {
   return sys_mmap(start, length, prot, flags, fd, offset);
 }
 
@@ -71,7 +71,7 @@ static inline void* do_mmap64(void *start, size_t length,
 
 static inline void* do_mmap64(void *start, size_t length,
                               int prot, int flags,
-                              int fd, __off64_t offset) __THROW {
+                              int fd, off64_t offset) __THROW {
   void *result;
 
   // Try mmap2() unless it's not supported
@@ -142,7 +142,7 @@ static inline void* do_mmap64(void *start, size_t length,
 
 extern "C" {
   void* mmap64(void *start, size_t length, int prot, int flags,
-               int fd, __off64_t offset  ) __THROW
+               int fd, off64_t offset  ) __THROW
     ATTRIBUTE_SECTION(malloc_hook);
   void* mmap(void *start, size_t length,int prot, int flags,
              int fd, off_t offset) __THROW
@@ -157,7 +157,7 @@ extern "C" {
 }
 
 extern "C" void* mmap64(void *start, size_t length, int prot, int flags,
-                        int fd, __off64_t offset) __THROW {
+                        int fd, off64_t offset) __THROW {
   MallocHook::InvokePreMmapHook(start, length, prot, flags, fd, offset);
   void *result;
   if (!MallocHook::InvokeMmapReplacement(


### PR DESCRIPTION
__off64_t is a kernel internal symbol, which happens to be user-visible
with glibc, but not necessarily with other C libraries such as musl.

Switching from __off64_t to off64_t allows the code to build properly
with musl.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>