### PR TITLE
Make _recalloc adhere to MS's definition

### DIFF
--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -1391,7 +1391,7 @@ ATTRIBUTE_ALWAYS_INLINE inline void* do_calloc(size_t n, size_t elem_size) {
 
   void* result = do_malloc_or_cpp_alloc(size);
   if (result != NULL) {
-    memset(result, 0, size);
+    memset(result, 0, tc_nallocx(size, 0));
   }
   return result;
 }


### PR DESCRIPTION
Although we still suffer from the fact that the value returned by tc_malloc_size could be larger than the actual requested size, it's the best what we can do I guess.

This essentially replaces a stale PR #714.