### PR TITLE
Patch _free_dbg to make Debug mode in MSVC works

### DIFF
--- a/src/windows/patch_functions.cc
+++ b/src/windows/patch_functions.cc
@@ -193,7 +193,9 @@ class LibcInfo {
     // These are windows-only functions from malloc.h
     k_Msize, k_Expand,
     // A MS CRT "internal" function, implemented using _calloc_impl
-    k_CallocCrt, kFreeBase,
+    k_CallocCrt,
+    // Underlying deallocation functions called by CRT internal functions or operator delete
+    kFreeBase, kFreeDbg,
     kNumFunctions
   };
 
@@ -277,6 +279,7 @@ template<int> class LibcInfoWithPatchFunctions : public LibcInfo {
   static void* Perftools_malloc(size_t size) __THROW;
   static void Perftools_free(void* ptr) __THROW;
   static void Perftools_free_base(void* ptr) __THROW;
+  static void Perftools_free_dbg(void* ptr, int block_use) __THROW;
   static void* Perftools_realloc(void* ptr, size_t size) __THROW;
   static void* Perftools_calloc(size_t nmemb, size_t size) __THROW;
   static void* Perftools_new(size_t size);
@@ -418,7 +421,7 @@ const char* const LibcInfo::function_name_[] = {
   NULL,  // kMangledNewArrayNothrow,
   NULL,  // kMangledDeleteNothrow,
   NULL,  // kMangledDeleteArrayNothrow,
-  "_msize", "_expand", "_calloc_crt", "_free_base"
+  "_msize", "_expand", "_calloc_crt", "_free_base", "_free_dbg"
 };
 
 // For mingw, I can't patch the new/delete here, because the
@@ -450,6 +453,7 @@ const GenericFnPtr LibcInfo::static_fn_[] = {
   (GenericFnPtr)&::_msize,
   (GenericFnPtr)&::_expand,
   (GenericFnPtr)&::calloc,
+  (GenericFnPtr)&::free,
   (GenericFnPtr)&::free
 };
 
@@ -474,7 +478,8 @@ const GenericFnPtr LibcInfoWithPatchFunctions<T>::perftools_fn_[] = {
   (GenericFnPtr)&Perftools__msize,
   (GenericFnPtr)&Perftools__expand,
   (GenericFnPtr)&Perftools_calloc,
-  (GenericFnPtr)&Perftools_free_base
+  (GenericFnPtr)&Perftools_free_base,
+  (GenericFnPtr)&Perftools_free_dbg
 };
 
 /*static*/ WindowsInfo::FunctionInfo WindowsInfo::function_info_[] = {
@@ -826,6 +831,18 @@ void LibcInfoWithPatchFunctions<T>::Perftools_free_base(void* ptr) __THROW{
   // *this* templatized instance of LibcInfo.  See "template
   // trickiness" above.
   do_free_with_callback(ptr, (void(*)(void*))origstub_fn_[kFreeBase], false, 0);
+}
+
+template<int T>
+void LibcInfoWithPatchFunctions<T>::Perftools_free_dbg(void* ptr, int block_use) __THROW {
+#ifdef _DEBUG
+  MallocHook::InvokeDeleteHook(ptr);
+  // The windows _free_dbg is called if ptr isn't owned by tcmalloc.
+  if (MallocExtension::instance()->GetOwnership(ptr) == MallocExtension::kOwned)
+    do_free(ptr);
+  else
+    reinterpret_cast<void (*)(void*, int)>(origstub_fn_[kFreeDbg])(ptr, block_use);
+#endif
 }
 
 template<int T>


### PR DESCRIPTION
Now tcmalloc_minimal_unittest and the other unittests PASS,  except one.

system-alloc_unittest fails with message:
```
Assertion failed: success == TRUE, file c:\users\holy\documents\visual studio 2017\projects\gperftools\src\windows\system-alloc.cc, line 166
```
and call stack:
```
ucrtbased.dll!0f7adcb0()
[Frames below may be incorrect and/or missing, no symbols loaded for ucrtbased.dll]
[External Code]
libtcmalloc_minimal.dll!TCMalloc_SystemRelease(void * start, unsigned int length) Line 166
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\windows\system-alloc.cc(166)
libtcmalloc_minimal.dll!tcmalloc::PageHeap::DecommitSpan(tcmalloc::Span * span) Line 249
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\page_heap.cc(249)
libtcmalloc_minimal.dll!tcmalloc::PageHeap::ReleaseSpan(tcmalloc::Span * s) Line 480
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\page_heap.cc(480)
libtcmalloc_minimal.dll!tcmalloc::PageHeap::ReleaseAtLeastNPages(unsigned int num_pages) Line 519
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\page_heap.cc(519)
libtcmalloc_minimal.dll!tcmalloc::PageHeap::New(unsigned int n) Line 149
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\page_heap.cc(149)
libtcmalloc_minimal.dll!`anonymous namespace'::do_malloc_pages(tcmalloc::ThreadCache * heap, unsigned int size) Line 1329
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tcmalloc.cc(1329)
libtcmalloc_minimal.dll!`anonymous namespace'::do_malloc(unsigned int size) Line 1357
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tcmalloc.cc(1357)
libtcmalloc_minimal.dll!tcmalloc::do_allocate_full<&tcmalloc::malloc_oom>(unsigned int size) Line 1758
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tcmalloc.cc(1758)
libtcmalloc_minimal.dll!tcmalloc::allocate_full_malloc_oom(unsigned int size) Line 1774
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tcmalloc.cc(1774)
libtcmalloc_minimal.dll!tcmalloc::dispatch_allocate_full<&tcmalloc::malloc_oom>(unsigned int size) Line 1787
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tcmalloc.cc(1787)
libtcmalloc_minimal.dll!malloc_fast_path<&tcmalloc::malloc_oom>(unsigned int size) Line 1846
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tcmalloc.cc(1846)
libtcmalloc_minimal.dll!`anonymous namespace'::LibcInfoWithPatchFunctions<0>::Perftools_malloc(unsigned int size) Line 813
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\windows\patch_functions.cc(813)
system-alloc_unittest.exe!TestBasicRetryFailTest() Line 139
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tests\system-alloc_unittest.cc(139)
system-alloc_unittest.exe!main(int argc, char * * argv) Line 153
	at c:\users\holy\documents\visual studio 2017\projects\gperftools\src\tests\system-alloc_unittest.cc(153)
```
Any thoughts?

By the way I have a question. Why there is always `c:\users\holy\documents\visual studio 2017\projects\gperftools\src\central_freelist.cc:333] tcmalloc: allocation failed 8192` at first line in tcmalloc_minimal_unittest, no matter x86/x64/Release/Debug mode? But it still PASSes.
EDIT: It seems no harm after tracing the call stack, so just ignore it.