### PR TITLE
Contributions and corrections to docs

### DIFF
--- a/README
+++ b/README
@@ -47,12 +47,20 @@ lowest for folks who use tcmalloc_minimal (or who, of course, compile with
 the above flags :-) ).
 
 
+QUICK INSTALLATION (linux)
+--------------------------
+
+sudo apt-get install google-perftools graphviz
+
+Note: graphical chart output from pprog requires graphvis.  If only textual output is needed, this package can be skipped.
+
+
 HEAP PROFILER
 -------------
 See docs/heapprofile.html for information about how to use tcmalloc's
 heap profiler and analyze its output.
 
-As a quick-start, do the following after installing this package:
+As a quick-start, do the following after installing:
 
 1) Link your executable with -ltcmalloc
 2) Run your executable with the HEAPPROFILE environment var set:
@@ -109,7 +117,7 @@ As a quick-start, here is one way to do so after having installed the gperftools
      $ CPUPROFILE=/tmp/prof.out <path/to/binary> [binary args]
 3) Run google-pprof to analyze the CPU usage eg.:
      $ google-pprof <path/to/binary> /tmp/prof.out      # -pg-like text output
-     $ google-pprof --gv <path/to/binary> /tmp/prof.out # really cool graphical chart output - requires "graphviz" package to be installed
+     $ google-pprof --gv <path/to/binary> /tmp/prof.out # really cool graphical chart output
 
 There are other environment variables, besides CPUPROFILE, you can set
 to adjust the cpu-profiler behavior; cf "ENVIRONMENT VARIABLES" below.

--- a/README
+++ b/README
@@ -50,9 +50,10 @@ the above flags :-) ).
 QUICK INSTALLATION (linux)
 --------------------------
 
-sudo apt-get install google-perftools graphviz
+sudo apt-get install google-perftools
+sudo apt-get install gv graphviz # Only required for graphical chart output from pprof
 
-Note: graphical chart output from pprog requires graphvis.  If only textual output is needed, this package can be skipped.
+Note: graphical chart output from pprog requires the "dot" package, which is included in graphvis, and "gv" (ghostview).
 
 
 HEAP PROFILER

--- a/README
+++ b/README
@@ -10,17 +10,17 @@ cpu-profiler.
 OVERVIEW
 ---------
 
-gperftools is a collection of a high-performance multi-threaded
-malloc() implementation, plus some pretty nifty performance analysis
+gperftools is a collection of both a high-performance multi-threaded
+malloc() implementation, and some pretty nifty performance analysis
 tools.
 
 gperftools is distributed under the terms of the BSD License. Join our
 mailing list at gperftools@googlegroups.com for updates:
 https://groups.google.com/forum/#!forum/gperftools
 
-gperftools was original home for pprof program. But do note that
-original pprof (which is still included with gperftools) is now
-deprecated in favor of golang version at https://github.com/google/pprof
+gperftools was originally the home for the google-pprof program. But please note that
+the original pprof (which is still included with gperftools) is now
+deprecated in favor of the golang version at https://github.com/google/pprof
 
 
 TCMALLOC
@@ -33,17 +33,17 @@ tcmalloc functionality is available on all systems we've tested; see
 INSTALL for more details.  See README_windows.txt for instructions on
 using tcmalloc on Windows.
 
-NOTE: When compiling with programs with gcc, that you plan to link
-with libtcmalloc, it's safest to pass in the flags
+NOTE: When compiling programs with gcc, if you plan to link
+with libtcmalloc, it's safer to compile with these flags:
 
  -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 
-when compiling.  gcc makes some optimizations assuming it is using its
-own, built-in malloc; that assumption obviously isn't true with
-tcmalloc.  In practice, we haven't seen any problems with this, but
+when compiling. gcc makes some optimizations which assume that it is using its
+own, built-in malloc; that assumption obviously isn't true when
+tcmalloc is being used. In practice, we haven't seen any problems with this, but
 the expected risk is highest for users who register their own malloc
-hooks with tcmalloc (using gperftools/malloc_hook.h).  The risk is
-lowest for folks who use tcmalloc_minimal (or, of course, who pass in
+hooks with tcmalloc (using gperftools/malloc_hook.h). The risk is
+lowest for folks who use tcmalloc_minimal (or who, of course, compile with
 the above flags :-) ).
 
 
@@ -57,9 +57,9 @@ As a quick-start, do the following after installing this package:
 1) Link your executable with -ltcmalloc
 2) Run your executable with the HEAPPROFILE environment var set:
      $ HEAPPROFILE=/tmp/heapprof <path/to/binary> [binary args]
-3) Run pprof to analyze the heap usage
-     $ pprof <path/to/binary> /tmp/heapprof.0045.heap  # run 'ls' to see options
-     $ pprof --gv <path/to/binary> /tmp/heapprof.0045.heap
+3) Run google-pprof to analyze the heap usage
+     $ google-pprof <path/to/binary> /tmp/heapprof.0045.heap  # run 'ls' to see options
+     $ google-pprof --gv <path/to/binary> /tmp/heapprof.0045.heap
 
 You can also use LD_PRELOAD to heap-profile an executable that you
 didn't compile.
@@ -83,9 +83,7 @@ accesses in libraries listed after it on the link line.  For instance,
 it may report these libraries as leaking memory when they're not.
 (See the source code for more details.)
 
-Here's a quick-start for how to use:
-
-As a quick-start, do the following after installing this package:
+Here's a quick-start for how to use after installing the gpreftools package:
 
 1) Link your executable with -ltcmalloc
 2) Run your executable with the HEAPCHECK environment var set:
@@ -103,16 +101,15 @@ for more details.
 CPU PROFILER
 ------------
 See docs/cpuprofile.html for information about how to use the CPU
-profiler and analyze its output.
-
-As a quick-start, do the following after installing this package:
+profiler and analyze its output. There are several different ways to use the profiler.
+As a quick-start, here is one way to do so after having installed the gperftools package:
 
 1) Link your executable with -lprofiler
 2) Run your executable with the CPUPROFILE environment var set:
      $ CPUPROFILE=/tmp/prof.out <path/to/binary> [binary args]
-3) Run pprof to analyze the CPU usage
-     $ pprof <path/to/binary> /tmp/prof.out      # -pg-like text output
-     $ pprof --gv <path/to/binary> /tmp/prof.out # really cool graphical output
+3) Run google-pprof to analyze the CPU usage eg.:
+     $ google-pprof <path/to/binary> /tmp/prof.out      # -pg-like text output
+     $ google-pprof --gv <path/to/binary> /tmp/prof.out # really cool graphical chart output - requires "graphviz" package to be installed
 
 There are other environment variables, besides CPUPROFILE, you can set
 to adjust the cpu-profiler behavior; cf "ENVIRONMENT VARIABLES" below.

--- a/cpuprofile-fileformat.html
+++ b/cpuprofile-fileformat.html
@@ -1,0 +1,264 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML>
+
+<HEAD>
+  <link rel="stylesheet" href="designstyle.css">
+  <title>Google CPU Profiler Binary Data File Format</title>
+</HEAD>
+
+<BODY>
+
+<h1>Google CPU Profiler Binary Data File Format</h1>
+
+<p align=right>
+  <i>Last modified
+    <script type=text/javascript>
+    var lm = new Date(document.lastModified);
+    document.write(lm.toDateString());
+  </script></i>
+</p>
+
+<p>This file documents the binary data file format produced by the
+Google CPU Profiler.  For information about using the CPU Profiler,
+see <a href="cpuprofile.html">its user guide</a>.
+
+<p>The profiler source code, which generates files using this format, is at
+<code>src/profiler.cc</code></a>.
+
+
+<h2>CPU Profile Data File Structure</h2>
+
+<p>CPU profile data files each consist of four parts, in order:
+
+<ul>
+  <li> Binary header
+  <li> Binary profile records
+  <li> Binary trailer
+  <li> Text list of mapped objects
+</ul>
+
+<p>The binary data is expressed in terms of "slots."  These are words
+large enough to hold the program's pointer type, i.e., for 32-bit
+programs they are 4 bytes in size, and for 64-bit programs they are 8
+bytes.  They are stored in the profile data file in the native byte
+order (i.e., little-endian for x86 and x86_64).
+
+
+<h2>Binary Header</h2>
+
+<p>The binary header format is show below.  Values written by the
+profiler, along with requirements currently enforced by the analysis
+tools, are shown in parentheses.
+
+<p>
+<table summary="Header Format"
+       frame="box" rules="sides" cellpadding="5" width="50%">
+  <tr>
+    <th width="30%">slot</th>
+    <th width="70%">data</th>
+  </tr>
+
+  <tr>
+    <td>0</td>
+    <td>header count (0; must be 0)</td>
+  </tr>
+
+  <tr>
+    <td>1</td>
+    <td>header slots after this one (3; must be &gt;= 3)</td>
+  </tr>
+
+  <tr>
+    <td>2</td>
+    <td>format version (0; must be 0)</td>
+  </tr>
+
+  <tr>
+    <td>3</td>
+    <td>sampling period, in microseconds</td>
+  </tr>
+
+  <tr>
+    <td>4</td>
+    <td>padding (0)</td>
+  </tr>
+</table>
+
+<p>The headers currently generated for 32-bit and 64-bit little-endian
+(x86 and x86_64) profiles are shown below, for comparison.
+
+<p>
+<table summary="Header Example" frame="box" rules="sides" cellpadding="5">
+  <tr>
+    <th></th>
+    <th>hdr count</th>
+    <th>hdr words</th>
+    <th>version</th>
+    <th>sampling period</th>
+    <th>pad</th>
+  </tr>
+  <tr>
+    <td>32-bit or 64-bit (slots)</td>
+    <td>0</td>
+    <td>3</td>
+    <td>0</td>
+    <td>10000</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>32-bit (4-byte words in file)</td>
+    <td><tt>0x00000</tt></td>
+    <td><tt>0x00003</tt></td>
+    <td><tt>0x00000</tt></td>
+    <td><tt>0x02710</tt></td>
+    <td><tt>0x00000</tt></td>
+  </tr>
+  <tr>
+    <td>64-bit LE (4-byte words in file)</td>
+    <td><tt>0x00000&nbsp;0x00000</tt></td>
+    <td><tt>0x00003&nbsp;0x00000</tt></td>
+    <td><tt>0x00000&nbsp;0x00000</tt></td>
+    <td><tt>0x02710&nbsp;0x00000</tt></td>
+    <td><tt>0x00000&nbsp;0x00000</tt></td>
+  </tr>
+</table>
+
+<p>The contents are shown in terms of slots, and in terms of 4-byte
+words in the profile data file.  The slot contents for 32-bit and
+64-bit headers are identical.  For 32-bit profiles, the 4-byte word
+view matches the slot view.  For 64-bit profiles, each (8-byte) slot
+is shown as two 4-byte words, ordered as they would appear in the
+file.
+
+<p>The profiling tools examine the contents of the file and use the
+expected locations and values of the header words field to detect
+whether the file is 32-bit or 64-bit.
+
+
+<h2>Binary Profile Records</h2>
+
+<p>The binary profile record format is shown below.
+
+<p>
+<table summary="Profile Record Format"
+       frame="box" rules="sides" cellpadding="5" width="50%">
+  <tr>
+    <th width="30%">slot</th>
+    <th width="70%">data</th>
+  </tr>
+
+  <tr>
+    <td>0</td>
+    <td>sample count, must be &gt;= 1</td>
+  </tr>
+
+  <tr>
+    <td>1</td>
+    <td>number of call chain PCs (num_pcs), must be &gt;= 1</td>
+  </tr>
+
+  <tr>
+    <td>2 .. (num_pcs + 1)</td>
+    <td>call chain PCs, most-recently-called function first.
+  </tr>
+</table>
+
+<p>The total length of a given record is 2 + num_pcs.
+
+<p>Note that multiple profile records can be emitted by the profiler
+having an identical call chain.  In that case, analysis tools should
+sum the counts of all records having identical call chains.
+
+<p><b>Note:</b> Some profile analysis tools terminate if they see
+<em>any</em> profile record with a call chain with its first entry
+having the address 0.  (This is similar to the binary trailer.)
+
+<h3>Example</h3>
+
+This example shows the slots contained in a sample profile record.
+
+<p>
+<table summary="Profile Record Example"
+       frame="box" rules="sides" cellpadding="5">
+  <tr>
+    <td>5</td>
+    <td>3</td>
+    <td>0xa0000</td>
+    <td>0xc0000</td>
+    <td>0xe0000</td>
+  </tr>
+</table>
+
+<p>In this example, 5 ticks were received at PC 0xa0000, whose
+function had been called by the function containing 0xc0000, which had
+been called from the function containing 0xe0000.
+
+
+<h2>Binary Trailer</h2>
+
+<p>The binary trailer consists of three slots of data with fixed
+values, shown below.
+
+<p>
+<table summary="Trailer Format"
+       frame="box" rules="sides" cellpadding="5" width="50%">
+  <tr>
+    <th width="30%">slot</th>
+    <th width="70%">value</th>
+  </tr>
+
+  <tr>
+    <td>0</td>
+    <td>0</td>
+  </tr>
+
+  <tr>
+    <td>1</td>
+    <td>1</td>
+  </tr>
+
+  <tr>
+    <td>2</td>
+    <td>0</td>
+  </tr>
+</table>
+
+<p>Note that this is the same data that would contained in a profile
+record with sample count = 0, num_pcs = 1, and a one-element call
+chain containing the address 0.
+
+
+<h2>Text List of Mapped Objects</h2>
+
+<p>The binary data in the file is followed immediately by a list of
+mapped objects.  This list consists of lines of text separated by
+newline characters.
+
+<p>Each line is one of the following types:
+
+<ul>
+  <li>Build specifier, starting with "<tt>build=</tt>".  For example:
+    <pre>  build=/path/to/binary</pre>
+    Leading spaces on the line are ignored.
+
+  <li>Mapping line from ProcMapsIterator::FormatLine.  For example:
+    <pre>  40000000-40015000 r-xp 00000000 03:01 12845071   /lib/ld-2.3.2.so</pre>
+    The first address must start at the beginning of the line.
+</ul>
+
+<p>Unrecognized lines should be ignored by analysis tools.
+
+<p>When processing the paths see in mapping lines, occurrences of
+<tt>$build</tt> followed by a non-word character (i.e., characters
+other than underscore or alphanumeric characters), should be replaced
+by the path given on the last build specifier line.
+
+<hr>
+<address>Chris Demetriou<br>
+<!-- Created: Mon Aug 27 12:18:26 PDT 2007 -->
+<!-- hhmts start -->
+Last modified: Mon Aug 27 12:18:26 PDT 2007  (cgd)
+<!-- hhmts end -->
+</address>
+</BODY>
+</HTML>

--- a/docs/cpuprofile.html
+++ b/docs/cpuprofile.html
@@ -1,8 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <HTML>
 
 <HEAD>
   <link rel="stylesheet" href="designstyle.css">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>Gperftools CPU Profiler</title>
 </HEAD>
 
@@ -45,10 +46,9 @@ system.)</p>
 
 <H1>Running the Code</H1>
 
-<p>There are several alternatives to actually turn on CPU profiling
-for a given run of an executable:</p>
+<p>There are 3 different ways to turn on CPU profiling for a given run of an executable:</p>
 
-<ol>
+<ol type="1">
   <li> <p>Define the environment variable CPUPROFILE to the filename
        to dump the profile to.  For instance, if you had a version of
        <code>/bin/ls</code> that had been linked against libprofiler,
@@ -69,11 +69,14 @@ for a given run of an executable:</p>
        generate the profile:</p>
        <pre>% killall -12 chrome</pre>
   </li>
-  <li> <p>In your code, bracket the code you want profiled in calls to
-       <code>ProfilerStart()</code> and <code>ProfilerStop()</code>.
-       (These functions are declared in <code>&lt;gperftools/profiler.h&gt;</code>.)
-       <code>ProfilerStart()</code> will take
-       the profile-filename as an argument.</p>
+  <li> <p>In your program, you can prefix and suffix the specific code you want profiled with calls to
+       <code>ProfilerStart()</code> and <code>ProfilerStop()</code> respectively
+       (these functions are declared in <code>&lt;gperftools/profiler.h&gt;</code>).
+       <code>ProfilerStart()</code> requires the profiler-output filename as an argument.<br>
+       eg.:<br>
+       <code>ProfilerStart("output.log");<br>
+       std::cout &lt;&lt; "Test" &lt;&lt; std::endl;<br>
+       ProfilerStop();</code></p>
   </li>
 </ol>
 
@@ -92,12 +95,12 @@ advanced-use functions, including <code>ProfilerFlush()</code> and
 <code>ProfilerStartWithOptions()</code>.</p>
 
 
-<H2>Modifying Runtime Behavior</H2>
+<H3>Modifying Runtime Behavior</H3>
 
 <p>You can more finely control the behavior of the CPU profiler via
 environment variables.</p>
 
-<table frame=box rules=sides cellpadding=5 width=100%>
+<table frame=box rules=cols cellpadding=5 width=100%>
 
 <tr valign=top>
   <td><code>CPUPROFILE_FREQUENCY=<i>x</i></code></td>
@@ -131,31 +134,31 @@ and others show the data in the form of a dependency graph.</p>
 
 <p>pprof <b>requires</b> <code>perl5</code> to be installed to run.
 It also requires <code>dot</code> to be installed for any of the
-graphical output routines, and <code>gv</code> to be installed for
-<code>--gv</code> mode (described below).
+graphical output routines, and <code>gv</code> (ghostview) to be installed for
+<code>--gv</code> mode (described below). <code>dot</code> is also included in the <code>graphvis</code> package.
 </p>
 
 <p>Here are some ways to call pprof.  These are described in more
 detail below.</p>
 
 <pre>
-% pprof /bin/ls ls.prof
+% google-pprof /bin/ls ls.prof
                        Enters "interactive" mode
-% pprof --text /bin/ls ls.prof
+% google-pprof --text /bin/ls ls.prof
                        Outputs one line per procedure
-% pprof --gv /bin/ls ls.prof
-                       Displays annotated call-graph via 'gv'
-% pprof --gv --focus=Mutex /bin/ls ls.prof
+% google-pprof --gv /bin/ls ls.prof
+                       Displays annotated call-graph via gv
+% google-pprof --gv --focus=Mutex /bin/ls ls.prof
                        Restricts to code paths including a .*Mutex.* entry
-% pprof --gv --focus=Mutex --ignore=string /bin/ls ls.prof
+% google-pprof --gv --focus=Mutex --ignore=string /bin/ls ls.prof
                        Code paths including Mutex but not string
-% pprof --list=getdir /bin/ls ls.prof
+% google-pprof --list=getdir /bin/ls ls.prof
                        (Per-line) annotated source listing for getdir()
-% pprof --disasm=getdir /bin/ls ls.prof
+% google-pprof --disasm=getdir /bin/ls ls.prof
                        (Per-PC) annotated disassembly for getdir()
-% pprof --text localhost:1234
+% google-pprof --text localhost:1234
                        Outputs one line per procedure for localhost:1234
-% pprof --callgrind /bin/ls ls.prof
+% google-pprof --callgrind /bin/ls ls.prof
                        Outputs the call information in callgrind format
 </pre>
 
@@ -169,12 +172,12 @@ detail below.</p>
 
 <p>Here is how to interpret the columns:</p>
 <ol>
-  <li> Number of profiling samples in this function
-  <li> Percentage of profiling samples in this function
-  <li> Percentage of profiling samples in the functions printed so far
-  <li> Number of profiling samples in this function and its callees
-  <li> Percentage of profiling samples in this function and its callees
-  <li> Function name
+  <li> Number of profiling samples in this function </li>
+  <li> Percentage of profiling samples in this function </li>
+  <li> Percentage of profiling samples in the functions printed so far </li>
+  <li> Number of profiling samples in this function and its callees    </li>
+  <li> Percentage of profiling samples in this function and its callees   </li>
+  <li> Function name </li>
 </ol>
 
 <h3>Analyzing Callgrind Output</h3>
@@ -182,7 +185,7 @@ detail below.</p>
 <p>Use <a href="http://kcachegrind.sourceforge.net">kcachegrind</a> to 
 analyze your callgrind output:</p>
 <pre>
-% pprof --callgrind /bin/ls ls.prof > ls.callgrind
+% google-pprof --callgrind /bin/ls ls.prof > ls.callgrind
 % kcachegrind ls.callgrind
 </pre>
 
@@ -283,7 +286,7 @@ call-graph is dropped on the floor.  For example, you can focus on the
 as follows:</p>
 
 <pre>
-% pprof --gv --focus=vsnprintf /tmp/profiler2_unittest test.prof
+% google-pprof --gv --focus=vsnprintf /tmp/profiler2_unittest test.prof
 </pre>
 <A HREF="pprof-vsnprintf-big.gif">
 <center><table><tr><td>
@@ -296,7 +299,7 @@ ignore samples that match a specified regular expression.  E.g., if
 you are interested in everything except calls to
 <code>snprintf()</code>, you can say:</p>
 <pre>
-% pprof --gv --ignore=snprintf /tmp/profiler2_unittest test.prof
+% google-pprof --gv --ignore=snprintf /tmp/profiler2_unittest test.prof
 </pre>
 
 
@@ -317,7 +320,7 @@ For a complete list of pprof options, you can run <code>pprof
 
 <p>
 <center>
-<table frame=box rules=sides cellpadding=5 width=100%>
+<table frame=box rules=cols cellpadding=5 width=100%>
 <tr valign=top>
   <td><code>--text</code></td>
   <td>
@@ -398,7 +401,7 @@ output.  The <code>--files</code> option seems to be particularly
 useless, and may be removed eventually.</p>
 
 <center>
-<table frame=box rules=sides cellpadding=5 width=100%>
+<table frame=box rules=cols cellpadding=5 width=100%>
 <tr valign=top>
   <td><code>--addresses</code></td>
   <td>
@@ -429,7 +432,7 @@ useless, and may be removed eventually.</p>
 display.  The following options control this effect:</p>
 
 <center>
-<table frame=box rules=sides cellpadding=5 width=100%>
+<table frame=box rules=cols cellpadding=5 width=100%>
 <tr valign=top>
   <td><code>--nodecount=&lt;n&gt;</code></td>
   <td>
@@ -487,7 +490,7 @@ display.  The following options control this effect:</p>
 </center>
 
 <p>The dropped edges and nodes account for some count mismatches in
-the display.  For example, the cumulative count for
+the display.  For example, the cumulative count for 
 <code>snprintf()</code> in the first diagram above was 41.  However
 the local count (1) and the count along the outgoing edges (12+1+20+6)
 add up to only 40.</p>
@@ -498,30 +501,30 @@ add up to only 40.</p>
 <ul>
   <li> If the program exits because of a signal, the generated profile
        will be <font color=red>incomplete, and may perhaps be
-       completely empty</font>.
+       completely empty</font>.</li>
   <li> The displayed graph may have disconnected regions because
-       of the edge-dropping heuristics described above.
+       of the edge-dropping heuristics described above.</li>
   <li> If the program linked in a library that was not compiled
        with enough symbolic information, all samples associated
        with the library may be charged to the last symbol found
        in the program before the library.  This will artificially
-       inflate the count for that symbol.
+       inflate the count for that symbol.</li>
   <li> If you run the program on one machine, and profile it on
        another, and the shared libraries are different on the two
        machines, the profiling output may be confusing: samples that
-       fall within  shared libaries may be assigned to arbitrary
-       procedures.
+       fall within shared libraries may be assigned to arbitrary
+       procedures.</li>
   <li> If your program forks, the children will also be profiled
        (since they inherit the same CPUPROFILE setting).  Each process
        is profiled separately; to distinguish the child profiles from
        the parent profile and from each other, all children will have
-       their process-id appended to the CPUPROFILE name.
-  <li> Due to a hack we make to work around a possible gcc bug, your
+       their process-id appended to the CPUPROFILE name.</li>
+  <li> Due to a hack we made to work around a possible gcc bug, your
        profiles may end up named strangely if the first character of
-       your CPUPROFILE variable has ascii value greater than 127.
+       your CPUPROFILE variable has an ascii value greater than 127.
        This should be exceedingly rare, but if you need to use such a
        name, just set prepend <code>./</code> to your filename:
-       <code>CPUPROFILE=./&Auml;gypten</code>.
+       <code>CPUPROFILE=./&Auml;gypten</code>.</li>
 </ul>
 
 
@@ -529,7 +532,7 @@ add up to only 40.</p>
 <address>Sanjay Ghemawat<br>
 <!-- Created: Tue Dec 19 10:43:14 PST 2000 -->
 <!-- hhmts start -->
-Last modified: Fri May  9 14:41:29 PDT 2008
+Last modified: May 23 2018
 <!-- hhmts end -->
 </address>
 </BODY>

--- a/heap_checker.html
+++ b/heap_checker.html
@@ -1,0 +1,534 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<HTML>
+
+<HEAD>
+  <link rel="stylesheet" href="designstyle.css">
+  <title>Gperftools Heap Leak Checker</title>
+</HEAD>
+
+<BODY>
+
+<p align=right>
+  <i>Last modified
+  <script type=text/javascript>
+    var lm = new Date(document.lastModified);
+    document.write(lm.toDateString());
+  </script></i>
+</p>
+
+<p>This is the heap checker we use at Google to detect memory leaks in
+C++ programs.  There are three parts to using it: linking the library
+into an application, running the code, and analyzing the output.</p>
+
+
+<H1>Linking in the Library</H1>
+
+<p>The heap-checker is part of tcmalloc, so to install the heap
+checker into your executable, add <code>-ltcmalloc</code> to the
+link-time step for your executable.  Also, while we don't necessarily
+recommend this form of usage, it's possible to add in the profiler at
+run-time using <code>LD_PRELOAD</code>:</p>
+<pre>% env LD_PRELOAD="/usr/lib/libtcmalloc.so" <binary></pre>
+
+<p>This does <i>not</i> turn on heap checking; it just inserts the
+code.  For that reason, it's practical to just always link
+<code>-ltcmalloc</code> into a binary while developing; that's what we
+do at Google.  (However, since any user can turn on the profiler by
+setting an environment variable, it's not necessarily recommended to
+install heapchecker-linked binaries into a production, running
+system.)  Note that if you wish to use the heap checker, you must
+also use the tcmalloc memory-allocation library.  There is no way
+currently to use the heap checker separate from tcmalloc.</p>
+
+
+<h1>Running the Code</h1>
+
+<p>Note: For security reasons, heap profiling will not write to a file
+-- and is thus not usable -- for setuid programs.</p>
+
+<h2><a name="whole_program">Whole-program Heap Leak Checking</a></h2>
+
+<p>The recommended way to use the heap checker is in "whole program"
+mode.  In this case, the heap-checker starts tracking memory
+allocations before the start of <code>main()</code>, and checks again
+at program-exit.  If it finds any memory leaks -- that is, any memory
+not pointed to by objects that are still "live" at program-exit -- it
+aborts the program (via <code>exit(1)</code>) and prints a message
+describing how to track down the memory leak (using <A
+HREF="heapprofile.html#pprof">pprof</A>).</p>
+
+<p>The heap-checker records the stack trace for each allocation while
+it is active. This causes a significant increase in memory usage, in
+addition to slowing your program down.</p>
+
+<p>Here's how to run a program with whole-program heap checking:</p>
+
+<ol>
+  <li> <p>Define the environment variable HEAPCHECK to the <A
+       HREF="#types">type of heap-checking</A> to do.  For instance,
+       to heap-check
+       <code>/usr/local/bin/my_binary_compiled_with_tcmalloc</code>:</p>
+       <pre>% env HEAPCHECK=normal /usr/local/bin/my_binary_compiled_with_tcmalloc</pre>
+</ol>
+
+<p>No other action is required.</p>
+
+<p>Note that since the heap-checker uses the heap-profiling framework
+internally, it is not possible to run both the heap-checker and <A
+HREF="heapprofile.html">heap profiler</A> at the same time.</p>
+
+
+<h3><a name="types">Flavors of Heap Checking</a></h3>
+
+<p>These are the legal values when running a whole-program heap
+check:</p>
+<ol>
+  <li> <code>minimal</code>
+  <li> <code>normal</code>
+  <li> <code>strict</code>
+  <li> <code>draconian</code>
+</ol>
+
+<p>"Minimal" heap-checking starts as late as possible in a
+initialization, meaning you can leak some memory in your
+initialization routines (that run before <code>main()</code>, say),
+and not trigger a leak message.  If you frequently (and purposefully)
+leak data in one-time global initializers, "minimal" mode is useful
+for you.  Otherwise, you should avoid it for stricter modes.</p>
+
+<p>"Normal" heap-checking tracks <A HREF="#live">live objects</A> and
+reports a leak for any data that is not reachable via a live object
+when the program exits.</p>
+
+<p>"Strict" heap-checking is much like "normal" but has a few extra
+checks that memory isn't lost in global destructors.  In particular,
+if you have a global variable that allocates memory during program
+execution, and then "forgets" about the memory in the global
+destructor (say, by setting the pointer to it to NULL) without freeing
+it, that will prompt a leak message in "strict" mode, though not in
+"normal" mode.</p>
+
+<p>"Draconian" heap-checking is appropriate for those who like to be
+very precise about their memory management, and want the heap-checker
+to help them enforce it.  In "draconian" mode, the heap-checker does
+not do "live object" checking at all, so it reports a leak unless
+<i>all</i> allocated memory is freed before program exit. (However,
+you can use <A HREF="#disable">IgnoreObject()</A> to re-enable
+liveness-checking on an object-by-object basis.)</p>
+
+<p>"Normal" mode, as the name implies, is the one used most often at
+Google.  It's appropriate for everyday heap-checking use.</p>
+
+<p>In addition, there are two other possible modes:</p>
+<ul>
+  <li> <code>as-is</code>
+  <li> <code>local</code>
+</ul>
+<p><code>as-is</code> is the most flexible mode; it allows you to
+specify the various <A HREF="#options">knobs</A> of the heap checker
+explicitly.  <code>local</code> activates the <A
+HREF="#explicit">explicit heap-check instrumentation</A>, but does not
+turn on any whole-program leak checking.</p>
+
+
+<h3><A NAME="tweaking">Tweaking whole-program checking</A></h3>
+
+<p>In some cases you want to check the whole program for memory leaks,
+but waiting for after <code>main()</code> exits to do the first
+whole-program leak check is waiting too long: e.g. in a long-running
+server one might wish to simply periodically check for leaks while the
+server is running.  In this case, you can call the static method
+<code>HeapLeakChecker::NoGlobalLeaks()</code>, to verify no global leaks have happened
+as of that point in the program.</p>
+
+<p>Alternately, doing the check after <code>main()</code> exits might
+be too late.  Perhaps you have some objects that are known not to
+clean up properly at exit.  You'd like to do the "at exit" check
+before those objects are destroyed (since while they're live, any
+memory they point to will not be considered a leak).  In that case,
+you can call <code>HeapLeakChecker::NoGlobalLeaks()</code> manually, near the end of
+<code>main()</code>, and then call <code>HeapLeakChecker::CancelGlobalCheck()</code> to
+turn off the automatic post-<code>main()</code> check.</p>
+
+<p>Finally, there's a helper macro for "strict" and "draconian" modes,
+which require all global memory to be freed before program exit.  This
+freeing can be time-consuming and is often unnecessary, since libc
+cleans up all memory at program-exit for you.  If you want the
+benefits of "strict"/"draconian" modes without the cost of all that
+freeing, look at <code>REGISTER_HEAPCHECK_CLEANUP</code> (in
+<code>heap-checker.h</code>).  This macro allows you to mark specific
+cleanup code as active only when the heap-checker is turned on.</p>
+
+
+<h2><a name="explicit">Explicit (Partial-program) Heap Leak Checking</h2>
+
+<p>Instead of whole-program checking, you can check certain parts of your
+code to verify they do not have memory leaks.  This check verifies that
+between two parts of a program, no memory is allocated without being freed.</p>
+<p>To use this kind of checking code, bracket the code you want
+checked by creating a <code>HeapLeakChecker</code> object at the
+beginning of the code segment, and call
+<code>NoLeaks()</code> at the end.  These functions, and all others
+referred to in this file, are declared in
+<code>&lt;gperftools/heap-checker.h&gt;</code>.
+</p>
+
+<p>Here's an example:</p>
+<pre>
+  HeapLeakChecker heap_checker("test_foo");
+  {
+    code that exercises some foo functionality;
+    this code should not leak memory;
+  }
+  if (!heap_checker.NoLeaks()) assert(NULL == "heap memory leak");
+</pre>
+
+<p>Note that adding in the <code>HeapLeakChecker</code> object merely
+instruments the code for leak-checking.  To actually turn on this
+leak-checking on a particular run of the executable, you must still
+run with the heap-checker turned on:</p>
+<pre>% env HEAPCHECK=local /usr/local/bin/my_binary_compiled_with_tcmalloc</pre>
+<p>If you want to do whole-program leak checking in addition to this
+manual leak checking, you can run in <code>normal</code> or some other
+mode instead: they'll run the "local" checks in addition to the
+whole-program check.</p>
+
+
+<h2><a name="disable">Disabling Heap-checking of Known Leaks</a></h2>
+
+<p>Sometimes your code has leaks that you know about and are willing
+to accept.  You would like the heap checker to ignore them when
+checking your program.  You can do this by bracketing the code in
+question with an appropriate heap-checking construct:</p>
+<pre>
+   ...
+   {
+     HeapLeakChecker::Disabler disabler;
+     &lt;leaky code&gt;
+   }
+   ...
+</pre>
+Any objects allocated by <code>leaky code</code> (including inside any
+routines called by <code>leaky code</code>) and any objects reachable
+from such objects are not reported as leaks.
+
+<p>Alternately, you can use <code>IgnoreObject()</code>, which takes a
+pointer to an object to ignore.  That memory, and everything reachable
+from it (by following pointers), is ignored for the purposes of leak
+checking.  You can call <code>UnIgnoreObject()</code> to undo the
+effects of <code>IgnoreObject()</code>.</p>
+
+
+<h2><a name="options">Tuning the Heap Checker</h2>
+
+<p>The heap leak checker has many options, some that trade off running
+time and accuracy, and others that increase the sensitivity at the
+risk of returning false positives.  For most uses, the range covered
+by the <A HREF="#types">heap-check flavors</A> is enough, but in
+specialized cases more control can be helpful.</p>
+
+<p>
+These options are specified via environment varaiables.
+</p>
+
+<p>This first set of options controls sensitivity and accuracy.  These
+options are ignored unless you run the heap checker in <A
+HREF="#types">as-is</A> mode.
+
+<table frame=box rules=sides cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_AFTER_DESTRUCTORS</code></td>
+  <td>Default: false</td>
+  <td>
+    When true, do the final leak check after all other global
+    destructors have run.  When false, do it after all
+    <code>REGISTER_HEAPCHECK_CLEANUP</code>, typically much earlier in
+    the global-destructor process.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_IGNORE_THREAD_LIVE</code></td>
+  <td>Default: true</td>
+  <td>
+    If true, ignore objects reachable from thread stacks and registers
+    (that is, do not report them as leaks).
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_IGNORE_GLOBAL_LIVE</code></td>
+  <td>Default: true</td>
+  <td>
+    If true, ignore objects reachable from global variables and data
+    (that is, do not report them as leaks).
+  </td>
+</tr>
+
+</table>
+
+<p>These options modify the behavior of whole-program leak
+checking.</p>
+
+<table frame=box rules=sides cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_MAX_LEAKS</code></td>
+  <td>Default: 20</td>
+  <td>
+    The maximum number of leaks to be printed to stderr (all leaks are still
+    emitted to file output for pprof to visualize). If negative or zero,
+    print all the leaks found.
+  </td>
+</tr>
+
+
+</table>
+
+<p>These options apply to all types of leak checking.</p>
+
+<table frame=box rules=sides cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_IDENTIFY_LEAKS</code></td>
+  <td>Default: false</td>
+  <td>
+    If true, generate the addresses of the leaked objects in the
+    generated memory leak profile files.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_TEST_POINTER_ALIGNMENT</code></td>
+  <td>Default: false</td>
+  <td>
+    If true, check all leaks to see if they might be due to the use
+    of unaligned pointers.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_POINTER_SOURCE_ALIGNMENT</code></td>
+  <td>Default: sizeof(void*)</td>
+  <td>
+    Alignment at which all pointers in memory are supposed to be located.
+    Use 1 if any alignment is ok.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>PPROF_PATH</code></td>
+  <td>Default: pprof</td>
+<td>
+    The location of the <code>pprof</code> executable.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_CHECK_DUMP_DIRECTORY</code></td>
+  <td>Default: /tmp</td>
+  <td>
+    Where the heap-profile files are kept while the program is running.
+  </td>
+</tr>
+
+</table>
+
+
+<h2>Tips for Handling Detected Leaks</h2>
+
+<p>What do you do when the heap leak checker detects a memory leak?
+First, you should run the reported <code>pprof</code> command;
+hopefully, that is enough to track down the location where the leak
+occurs.</p>
+
+<p>If the leak is a real leak, you should fix it!</p>
+
+<p>If you are sure that the reported leaks are not dangerous and there
+is no good way to fix them, then you can use
+<code>HeapLeakChecker::Disabler</code> and/or
+<code>HeapLeakChecker::IgnoreObject()</code> to disable heap-checking
+for certain parts of the codebase.</p>
+
+<p>In "strict" or "draconian" mode, leaks may be due to incomplete
+cleanup in the destructors of global variables.  If you don't wish to
+augment the cleanup routines, but still want to run in "strict" or
+"draconian" mode, consider using <A
+HREF="#tweaking"><code>REGISTER_HEAPCHECK_CLEANUP</code></A>.</p>
+
+<h2>Hints for Debugging Detected Leaks</h2>
+
+<p>Sometimes it can be useful to not only know the exact code that
+allocates the leaked objects, but also the addresses of the leaked objects.
+Combining this e.g. with additional logging in the program
+one can then track which subset of the allocations
+made at a certain spot in the code are leaked.
+<br/>
+To get the addresses of all leaked objects
+  define the environment variable <code>HEAP_CHECK_IDENTIFY_LEAKS</code>
+  to be <code>1</code>.
+The object addresses will be reported in the form of addresses
+of fake immediate callers of the memory allocation routines.
+Note that the performance of doing leak-checking in this mode
+can be noticeably worse than the default mode.
+</p>
+
+<p>One relatively common class of leaks that don't look real
+is the case of multiple initialization.
+In such cases the reported leaks are typically things that are
+linked from some global objects,
+which are initialized and say never modified again.
+The non-obvious cause of the leak is frequently the fact that
+the initialization code for these objects executes more than once.
+<br/>
+E.g. if the code of some <code>.cc</code> file is made to be included twice
+into the binary, then the constructors for global objects defined in that file
+will execute twice thus leaking the things allocated on the first run.
+<br/>
+Similar problems can occur if object initialization is done more explicitly
+e.g. on demand by a slightly buggy code
+that does not always ensure only-once initialization.
+</p>
+
+<p>
+A more rare but even more puzzling problem can be use of not properly
+aligned pointers (maybe inside of not properly aligned objects).
+Normally such pointers are not followed by the leak checker,
+hence the objects reachable only via such pointers are reported as leaks.
+If you suspect this case
+  define the environment variable <code>HEAP_CHECK_TEST_POINTER_ALIGNMENT</code>
+  to be <code>1</code>
+and then look closely at the generated leak report messages.
+</p>
+
+<h1>How It Works</h1>
+
+<p>When a <code>HeapLeakChecker</code> object is constructed, it dumps
+a memory-usage profile named
+<code>&lt;prefix&gt;.&lt;name&gt;-beg.heap</code> to a temporary
+directory.  When <code>NoLeaks()</code>
+is called (for whole-program checking, this happens automatically at
+program-exit), it dumps another profile, named
+<code>&lt;prefix&gt;.&lt;name&gt;-end.heap</code>.
+(<code>&lt;prefix&gt;</code> is typically determined automatically,
+and <code>&lt;name&gt;</code> is typically <code>argv[0]</code>.)  It
+then compares the two profiles.  If the second profile shows
+more memory use than the first, the
+<code>NoLeaks()</code> function will
+return false.  For "whole program" profiling, this will cause the
+executable to abort (via <code>exit(1)</code>).  In all cases, it will
+print a message on how to process the dumped profiles to locate
+leaks.</p>
+
+<h3><A name=live>Detecting Live Objects</A></h3>
+
+<p>At any point during a program's execution, all memory that is
+accessible at that time is considered "live."  This includes global
+variables, and also any memory that is reachable by following pointers
+from a global variable.  It also includes all memory reachable from
+the current stack frame and from current CPU registers (this captures
+local variables).  Finally, it includes the thread equivalents of
+these: thread-local storage and thread heaps, memory reachable from
+thread-local storage and thread heaps, and memory reachable from
+thread CPU registers.</p>
+
+<p>In all modes except "draconian," live memory is not
+considered to be a leak.  We detect this by doing a liveness flood,
+traversing pointers to heap objects starting from some initial memory
+regions we know to potentially contain live pointer data.  Note that
+this flood might potentially not find some (global) live data region
+to start the flood from.  If you find such, please file a bug.</p>
+
+<p>The liveness flood attempts to treat any properly aligned byte
+sequences as pointers to heap objects and thinks that it found a good
+pointer whenever the current heap memory map contains an object with
+the address whose byte representation we found.  Some pointers into
+not-at-start of object will also work here.</p>
+
+<p>As a result of this simple approach, it's possible (though
+unlikely) for the flood to be inexact and occasionally result in
+leaked objects being erroneously determined to be live.  For instance,
+random bit patterns can happen to look like pointers to leaked heap
+objects.  More likely, stale pointer data not corresponding to any
+live program variables can be still present in memory regions,
+especially in thread stacks.  For instance, depending on how the local
+<code>malloc</code> is implemented, it may reuse a heap object
+address:</p>
+<pre>
+    char* p = new char[1];   // new might return 0x80000000, say.
+    delete p;
+    new char[1];             // new might return 0x80000000 again
+    // This last new is a leak, but doesn't seem it: p looks like it points to it
+</pre>
+
+<p>In other words, imprecisions in the liveness flood mean that for
+any heap leak check we might miss some memory leaks.  This means that
+for local leak checks, we might report a memory leak in the local
+area, even though the leak actually happened before the
+<code>HeapLeakChecker</code> object was constructed.  Note that for
+whole-program checks, a leak report <i>does</i> always correspond to a
+real leak (since there's no "before" to have created a false-live
+object).</p>
+
+<p>While this liveness flood approach is not very portable and not
+100% accurate, it works in most cases and saves us from writing a lot
+of explicit clean up code and other hassles when dealing with thread
+data.</p>
+
+
+<h3>Visualizing Leak with <code>pprof</code></h3>
+
+<p>
+The heap checker automatically prints basic leak info with stack traces of
+leaked objects' allocation sites, as well as a pprof command line that can be
+used to visualize the call-graph involved in these allocations.
+The latter can be much more useful for a human
+to see where/why the leaks happened, especially if the leaks are numerous.
+</p>
+
+<h3>Leak-checking and Threads</h3>
+
+<p>At the time of HeapLeakChecker's construction and during
+<code>NoLeaks()</code> calls, we grab a lock
+and then pause all other threads so other threads do not interfere
+with recording or analyzing the state of the heap.</p>
+
+<p>In general, leak checking works correctly in the presence of
+threads.  However, thread stack data liveness determination (via
+<code>base/thread_lister.h</code>) does not work when the program is
+running under GDB, because the ptrace functionality needed for finding
+threads is already hooked to by GDB.  Conversely, leak checker's
+ptrace attempts might also interfere with GDB.  As a result, GDB can
+result in potentially false leak reports.  For this reason, the
+heap-checker turns itself off when running under GDB.</p>
+
+<p>Also, <code>thread_lister</code> only works for Linux pthreads;
+leak checking is unlikely to handle other thread implementations
+correctly.</p>
+
+<p>As mentioned in the discussion of liveness flooding, thread-stack
+liveness determination might mis-classify as reachable objects that
+very recently became unreachable (leaked).  This can happen when the
+pointers to now-logically-unreachable objects are present in the
+active thread stack frame.  In other words, trivial code like the
+following might not produce the expected leak checking outcome
+depending on how the compiled code works with the stack:</p>
+<pre>
+  int* foo = new int [20];
+  HeapLeakChecker check("a_check");
+  foo = NULL;
+  // May fail to trigger.
+  if (!heap_checker.NoLeaks()) assert(NULL == "heap memory leak");
+</pre>
+
+
+<hr>
+<address>Maxim Lifantsev<br>
+<!-- Created: Tue Dec 19 10:43:14 PST 2000 -->
+<!-- hhmts start -->
+Last modified: Fri Jul 13 13:14:33 PDT 2007
+<!-- hhmts end -->
+</address>
+</body>
+</html>

--- a/heapprofile.html
+++ b/heapprofile.html
@@ -1,0 +1,391 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<HEAD>
+  <link rel="stylesheet" href="designstyle.css">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Gperftools Heap Profiler</title>
+</HEAD>
+
+<BODY>
+
+<p align=right>
+  <i>Last modified
+  <script type=text/javascript>
+    var lm = new Date(document.lastModified);
+    document.write(lm.toDateString());
+  </script></i>
+</p>
+
+<p>This is the heap profiler we use at Google, to explore how C++
+programs manage memory.  This facility can be useful for</p>
+<ul>
+  <li> Figuring out what is in the program heap at any given time
+  <li> Locating memory leaks
+  <li> Finding places that do a lot of allocation
+</ul>
+
+<p>The profiling system instruments all allocations and frees.  It
+keeps track of various pieces of information per allocation site.  An
+allocation site is defined as the active stack trace at the call to
+<code>malloc</code>, <code>calloc</code>, <code>realloc</code>, or,
+<code>new</code>.</p>
+
+<p>There are three parts to using it: linking the library into an
+application, running the code, and analyzing the output.</p>
+
+
+<h1>Linking in the Library</h1>
+
+<p>To install the heap profiler into your executable, add
+<code>-ltcmalloc</code> to the link-time step for your executable.
+Also, while we don't necessarily recommend this form of usage, it's
+possible to add in the profiler at run-time using
+<code>LD_PRELOAD</code>:
+<pre>% env LD_PRELOAD="/usr/lib/libtcmalloc.so" &lt;binary&gt;</pre>
+
+<p>This does <i>not</i> turn on heap profiling; it just inserts the
+code.  For that reason, it's practical to just always link
+<code>-ltcmalloc</code> into a binary while developing; that's what we
+do at Google.  (However, since any user can turn on the profiler by
+setting an environment variable, it's not necessarily recommended to
+install profiler-linked binaries into a production, running
+system.)  Note that if you wish to use the heap profiler, you must
+also use the tcmalloc memory-allocation library.  There is no way
+currently to use the heap profiler separate from tcmalloc.</p>
+
+
+<h1>Running the Code</h1>
+
+<p>There are several alternatives to actually turn on heap profiling
+for a given run of an executable:</p>
+
+<ol>
+  <li> <p>Define the environment variable HEAPPROFILE to the filename
+       to dump the profile to.  For instance, to profile
+       <code>/usr/local/bin/my_binary_compiled_with_tcmalloc</code>:</p>
+       <pre>% env HEAPPROFILE=/tmp/mybin.hprof /usr/local/bin/my_binary_compiled_with_tcmalloc</pre></li>
+  <li> <p>In your code, bracket the code you want profiled in calls to
+       <code>HeapProfilerStart()</code> and <code>HeapProfilerStop()</code>.
+       (These functions are declared in <code>&lt;gperftools/heap-profiler.h&gt;</code>.)
+       <code>HeapProfilerStart()</code> will take the
+       profile-filename-prefix as an argument.  Then, as often as
+       you'd like before calling <code>HeapProfilerStop()</code>, you
+       can use <code>HeapProfilerDump()</code> or
+       <code>GetHeapProfile()</code> to examine the profile.  In case
+       it's useful, <code>IsHeapProfilerRunning()</code> will tell you
+       whether you've already called HeapProfilerStart() or not.</p></li>
+</ol>
+
+
+<p>For security reasons, heap profiling will not write to a file --
+and is thus not usable -- for setuid programs.</p>
+
+<H2>Modifying Runtime Behavior</H2>
+
+<p>You can more finely control the behavior of the heap profiler via
+environment variables.</p>
+
+<table frame=box rules=cols cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>HEAP_PROFILE_ALLOCATION_INTERVAL</code></td>
+  <td>default: 1073741824 (1 Gb)</td>
+  <td>
+    Dump heap profiling information each time the specified number of
+    bytes has been allocated by the program.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_PROFILE_INUSE_INTERVAL</code></td>
+  <td>default: 104857600 (100 Mb)</td>
+  <td>
+    Dump heap profiling information whenever the high-water memory
+    usage mark increases by the specified number of bytes.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_PROFILE_TIME_INTERVAL</code></td>
+  <td>default: 0</td>
+  <td>
+    Dump heap profiling information each time the specified
+    number of seconds has elapsed.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAPPROFILESIGNAL</code></td>
+  <td>default: disabled</td>
+  <td>
+    Dump heap profiling information whenever the specified signal is sent to the
+    process.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_PROFILE_MMAP</code></td>
+  <td>default: false</td>
+  <td>
+    Profile <code>mmap</code>, <code>mremap</code> and <code>sbrk</code>
+    calls in addition
+    to <code>malloc</code>, <code>calloc</code>, <code>realloc</code>,
+    and <code>new</code>.  <b>NOTE:</b> this causes the profiler to
+    profile calls internal to tcmalloc, since tcmalloc and friends use
+    mmap and sbrk internally for allocations.  One partial solution is
+    to filter these allocations out when running <code>pprof</code>,
+    with something like
+    <code>pprof --ignore='DoAllocWithArena|SbrkSysAllocator::Alloc|MmapSysAllocator::Alloc</code>.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_PROFILE_ONLY_MMAP</code></td>
+  <td>default: false</td>
+  <td>
+    Only profile <code>mmap</code>, <code>mremap</code>, and <code>sbrk</code>
+    calls; do not profile
+    <code>malloc</code>, <code>calloc</code>, <code>realloc</code>,
+    or <code>new</code>.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>HEAP_PROFILE_MMAP_LOG</code></td>
+  <td>default: false</td>
+  <td>
+    Log <code>mmap</code>/<code>munmap</code> calls.
+  </td>
+</tr>
+
+</table>
+
+<H2>Checking for Leaks</H2>
+
+<p>You can use the heap profiler to manually check for leaks, for
+instance by reading the profiler output and looking for large
+allocations.  However, for that task, it's easier to use the <A
+HREF="heap_checker.html">automatic heap-checking facility</A> built
+into tcmalloc.</p>
+
+
+<h1><a name="pprof">Analyzing the Output</a></h1>
+
+<p>If heap-profiling is turned on in a program, the program will
+periodically write profiles to the filesystem.  The sequence of
+profiles will be named:</p>
+<pre>
+           &lt;prefix&gt;.0000.heap
+           &lt;prefix&gt;.0001.heap
+           &lt;prefix&gt;.0002.heap
+           ...
+</pre>
+<p>where <code>&lt;prefix&gt;</code> is the filename-prefix supplied
+when running the code (e.g. via the <code>HEAPPROFILE</code>
+environment variable).  Note that if the supplied prefix
+does not start with a <code>/</code>, the profile files will be
+written to the program's working directory.</p>
+
+<p>The profile output can be viewed by passing it to the
+<code>pprof</code> tool -- the same tool that's used to analyze <A
+HREF="cpuprofile.html">CPU profiles</A>.
+
+<p>Here are some examples.  These examples assume the binary is named
+<code>gfs_master</code>, and a sequence of heap profile files can be
+found in files named:</p>
+<pre>
+  /tmp/profile.0001.heap
+  /tmp/profile.0002.heap
+  ...
+  /tmp/profile.0100.heap
+</pre>
+
+<h3>Why is a process so big</h3>
+
+<pre>
+    % pprof --gv gfs_master /tmp/profile.0100.heap
+</pre>
+
+<p>This command will pop-up a <code>gv</code> window that displays
+the profile information as a directed graph.  Here is a portion
+of the resulting output:</p>
+
+<p><center>
+<img src="heap-example1.png">
+</center></p>
+
+A few explanations:
+<ul>
+<li> <code>GFS_MasterChunk::AddServer</code> accounts for 255.6 MB
+     of the live memory, which is 25% of the total live memory.
+<li> <code>GFS_MasterChunkTable::UpdateState</code> is directly
+     accountable for 176.2 MB of the live memory (i.e., it directly
+     allocated 176.2 MB that has not been freed yet).  Furthermore,
+     it and its callees are responsible for 729.9 MB.  The
+     labels on the outgoing edges give a good indication of the
+     amount allocated by each callee.
+</ul>
+
+<h3>Comparing Profiles</h3>
+
+<p>You often want to skip allocations during the initialization phase
+of a program so you can find gradual memory leaks.  One simple way to
+do this is to compare two profiles -- both collected after the program
+has been running for a while.  Specify the name of the first profile
+using the <code>--base</code> option.  For example:</p>
+<pre>
+   % pprof --base=/tmp/profile.0004.heap gfs_master /tmp/profile.0100.heap
+</pre>
+
+<p>The memory-usage in <code>/tmp/profile.0004.heap</code> will be
+subtracted from the memory-usage in
+<code>/tmp/profile.0100.heap</code> and the result will be
+displayed.</p>
+
+<h3>Text display</h3>
+
+<pre>
+% pprof --text gfs_master /tmp/profile.0100.heap
+   255.6  24.7%  24.7%    255.6  24.7% GFS_MasterChunk::AddServer
+   184.6  17.8%  42.5%    298.8  28.8% GFS_MasterChunkTable::Create
+   176.2  17.0%  59.5%    729.9  70.5% GFS_MasterChunkTable::UpdateState
+   169.8  16.4%  75.9%    169.8  16.4% PendingClone::PendingClone
+    76.3   7.4%  83.3%     76.3   7.4% __default_alloc_template::_S_chunk_alloc
+    49.5   4.8%  88.0%     49.5   4.8% hashtable::resize
+   ...
+</pre>
+
+<p>
+<ul>
+  <li> The first column contains the direct memory use in MB.</li>
+  <li> The fourth column contains memory use by the procedure
+       and all of its callees.</li>
+  <li> The second and fifth columns are just percentage
+       representations of the numbers in the first and fourth columns.</li>
+  <li> The third column is a cumulative sum of the second column
+       (i.e., the <code>k</code>th entry in the third column is the
+       sum of the first <code>k</code> entries in the second column.)</li>
+</ul>
+
+<h3>Ignoring or focusing on specific regions</h3>
+
+<p>The following command will give a graphical display of a subset of
+the call-graph.  Only paths in the call-graph that match the regular
+expression <code>DataBuffer</code> are included:</p>
+<pre>
+% pprof --gv --focus=DataBuffer gfs_master /tmp/profile.0100.heap
+</pre>
+
+<p>Similarly, the following command will omit all paths subset of the
+call-graph.  All paths in the call-graph that match the regular
+expression <code>DataBuffer</code> are discarded:</p>
+<pre>
+% pprof --gv --ignore=DataBuffer gfs_master /tmp/profile.0100.heap
+</pre>
+
+<h3>Total allocations + object-level information</h3>
+
+<p>All of the previous examples have displayed the amount of in-use
+space.  I.e., the number of bytes that have been allocated but not
+freed.  You can also get other types of information by supplying a
+flag to <code>pprof</code>:</p>
+
+<center>
+<table frame=box rules=cols cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>--inuse_space</code></td>
+  <td>
+     Display the number of in-use megabytes (i.e. space that has
+     been allocated but not freed).  This is the default.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>--inuse_objects</code></td>
+  <td>
+     Display the number of in-use objects (i.e. number of
+     objects that have been allocated but not freed).
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>--alloc_space</code></td>
+  <td>
+     Display the number of allocated megabytes.  This includes
+     the space that has since been de-allocated.  Use this
+     if you want to find the main allocation sites in the
+     program.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>--alloc_objects</code></td>
+  <td>
+     Display the number of allocated objects.  This includes
+     the objects that have since been de-allocated.  Use this
+     if you want to find the main allocation sites in the
+     program.
+  </td>
+
+</table>
+</center>
+
+
+<h3>Interactive mode</a></h3>
+
+<p>By default -- if you don't specify any flags to the contrary --
+pprof runs in interactive mode.  At the <code>(pprof)</code> prompt,
+you can run many of the commands described above.  You can type
+<code>help</code> for a list of what commands are available in
+interactive mode.</p>
+
+
+<h1>Caveats</h1>
+
+<ul>
+  <li> Heap profiling requires the use of libtcmalloc.  This
+       requirement may be removed in a future version of the heap
+       profiler, and the heap profiler separated out into its own
+       library.</li>
+     
+  <li> If the program linked in a library that was not compiled
+       with enough symbolic information, all samples associated
+       with the library may be charged to the last symbol found
+       in the program before the library.  This will artificially
+       inflate the count for that symbol.</li>
+
+  <li> If you run the program on one machine, and profile it on
+       another, and the shared libraries are different on the two
+       machines, the profiling output may be confusing: samples that
+       fall within the shared libaries may be assigned to arbitrary
+       procedures.</li>
+
+  <li> Several libraries, such as some STL implementations, do their
+       own memory management.  This may cause strange profiling
+       results.  We have code in libtcmalloc to cause STL to use
+       tcmalloc for memory management (which in our tests is better
+       than STL's internal management), though it only works for some
+       STL implementations.</li>
+
+  <li> If your program forks, the children will also be profiled
+       (since they inherit the same HEAPPROFILE setting).  Each
+       process is profiled separately; to distinguish the child
+       profiles from the parent profile and from each other, all
+       children will have their process-id attached to the HEAPPROFILE
+       name.</li>
+     
+  <li> Due to a hack we make to work around a possible gcc bug, your
+       profiles may end up named strangely if the first character of
+       your HEAPPROFILE variable has ascii value greater than 127.
+       This should be exceedingly rare, but if you need to use such a
+       name, just set prepend <code>./</code> to your filename:
+       <code>HEAPPROFILE=./&Auml;gypten</code>.</li>
+</ul>
+
+<hr>
+<address>Sanjay Ghemawat
+<!-- Created: Tue Dec 19 10:43:14 PST 2000 -->
+</address>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<HTML>
+
+<HEAD>
+<title>Gperftools</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</HEAD>
+
+<BODY>
+<ul>
+  <li> <A HREF="tcmalloc.html">thread-caching malloc</A></li>
+  <li> <A HREF="heap_checker.html">heap-checking using tcmalloc</A></li>
+  <li> <A HREF="heapprofile.html">heap-profiling using tcmalloc</A></li>
+  <li> <A HREF="cpuprofile.html">CPU profiler</A></li>
+</ul>
+
+<hr>
+Last modified: 23rd May 2018
+
+</BODY>
+
+</HTML>

--- a/pprof_remote_servers.html
+++ b/pprof_remote_servers.html
@@ -1,0 +1,263 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<HTML>
+
+<HEAD>
+<title>pprof and Remote Servers</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</HEAD>
+
+<BODY>
+
+<h1><code>pprof</code> and Remote Servers</h1>
+
+<p>In mid-2006, we added an experimental facility to <A
+HREF="cpu_profiler.html">pprof</A>, the tool that analyzes CPU and
+heap profiles.  This facility allows you to collect profile
+information from running applications.  It makes it easy to collect
+profile information without having to stop the program first, and
+without having to log into the machine where the application is
+running.  This is meant to be used on webservers, but will work on any
+application that can be modified to accept TCP connections on a port
+of its choosing, and to respond to HTTP requests on that port.</p>
+
+<p>We do not currently have infrastructure, such as apache modules,
+that you can pop into a webserver or other application to get the
+necessary functionality "for free."  However, it's easy to generate
+the necessary data, which should allow the interested developer to add
+the necessary support into his or her applications.</p>
+
+<p>To use <code>pprof</code> in this experimental "server" mode, you
+give the script a host and port it should query, replacing the normal
+commandline arguments of application + profile file:</p>
+<pre>
+   % pprof internalweb.mycompany.com:80
+</pre>
+
+<p>The host must be listening on that port, and be able to accept HTTP/1.0
+requests -- sent via <code>wget</code> and <code>curl</code> -- for
+several urls.  The following sections list the urls that
+<code>pprof</code> can send, and the responses it expects in
+return.</p>
+
+<p>Here are examples that pprof will recognize, when you give them
+on the commandline, are urls.  In general, you
+specify the host and a port (the port-number is required), and put
+the service-name at the end of the url.:</p>
+<blockquote><pre>
+http://myhost:80/pprof/heap            # retrieves a heap profile
+http://myhost:8008/pprof/profile       # retrieves a CPU profile
+http://myhost:80                       # retrieves a CPU profile (the default)
+http://myhost:8080/                    # retrieves a CPU profile (the default)
+myhost:8088/pprof/growth               # "http://" is optional, but port is not
+http://myhost:80/myservice/pprof/heap  # /pprof/heap just has to come at the end
+http://myhost:80/pprof/pmuprofile      # CPU profile using performance counters
+</pre></blockquote>
+
+<h2> <code><b>/pprof/heap</b></code> </h2>
+
+<p><code>pprof</code> asks for the url <code>/pprof/heap</code> to
+get heap information.  The actual url is controlled via the variable
+<code>HEAP_PAGE</code> in the <code>pprof</code> script, so you
+can change it if you'd like.</p>
+
+<p>There are two ways to get this data.  The first is to call</p>
+<pre>
+    MallocExtension::instance()->GetHeapSample(&output);
+</pre>
+<p>and have the server send <code>output</code> back as an HTTP
+response to <code>pprof</code>.  <code>MallocExtension</code> is
+defined in the header file <code>gperftools/malloc_extension.h</code>.</p>
+
+<p>Note this will only only work if the binary is being run with
+sampling turned on (which is not the default).  To do this, set the
+environment variable <code>TCMALLOC_SAMPLE_PARAMETER</code> to a
+positive value, such as 524288, before running.</p>
+
+<p>The other way is to call <code>HeapProfileStart(filename)</code>
+(from <code>heap-profiler.h</code>), continue to do work, and then,
+some number of seconds later, call <code>GetHeapProfile()</code>
+(followed by <code>HeapProfilerStop()</code>).  The server can send
+the output of <code>GetHeapProfile</code> back as the HTTP response to
+pprof.  (Note you must <code>free()</code> this data after using it.)
+This is similar to how <A HREF="#profile">profile requests</A> are
+handled, below.  This technique does not require the application to
+run with sampling turned on.</p>
+
+<p>Here's an example of what the output should look like:</p>
+<pre>
+heap profile:   1923: 127923432 [  1923: 127923432] @ heap_v2/524288
+     1:      312 [     1:      312] @ 0x2aaaabaf5ccc 0x2aaaaba4cd2c 0x2aaaac08c09a
+   928: 122586016 [   928: 122586016] @ 0x2aaaabaf682c 0x400680 0x400bdd 0x2aaaab1c368a 0x2aaaab1c8f77 0x2aaaab1c0396 0x2aaaab1c86ed 0x4007ff 0x2aaaaca62afa
+     1:       16 [     1:       16] @ 0x2aaaabaf5ccc 0x2aaaabb04bac 0x2aaaabc1b262 0x2aaaabc21496 0x2aaaabc214bb
+[...]
+</pre>
+
+
+<p> Older code may produce "version 1" heap profiles which look like this:<p/>
+<pre>
+heap profile:  14933: 791700132 [ 14933: 791700132] @ heap
+     1:   848688 [     1:   848688] @ 0xa4b142 0x7f5bfc 0x87065e 0x4056e9 0x4125f8 0x42b4f1 0x45b1ba 0x463248 0x460871 0x45cb7c 0x5f1744 0x607cee 0x5f4a5e 0x40080f 0x2aaaabad7afa
+     1:  1048576 [     1:  1048576] @ 0xa4a9b2 0x7fd025 0x4ca6d8 0x4ca814 0x4caa88 0x2aaaab104cf0 0x404e20 0x4125f8 0x42b4f1 0x45b1ba 0x463248 0x460871 0x45cb7c 0x5f1744 0x607cee 0x5f4a5e 0x40080f 0x2aaaabad7afa
+  2942: 388629374 [  2942: 388629374] @ 0xa4b142 0x4006a0 0x400bed 0x5f0cfa 0x5f1744 0x607cee 0x5f4a5e 0x40080f 0x2aaaabad7afa
+[...]
+</pre>
+<p>pprof accepts both old and new heap profiles and automatically
+detects which one you are using.</p>
+
+<h2> <code><b>/pprof/growth</b></code> </h2>
+
+<p><code>pprof</code> asks for the url <code>/pprof/growth</code> to
+get heap-profiling delta (growth) information.  The actual url is
+controlled via the variable <code>GROWTH_PAGE</code> in the
+<code>pprof</code> script, so you can change it if you'd like.</p>
+
+<p>The server should respond by calling</p>
+<pre>
+    MallocExtension::instance()->GetHeapGrowthStacks(&output);
+</pre>
+<p>and sending <code>output</code> back as an HTTP response to
+<code>pprof</code>.  <code>MallocExtension</code> is defined in the
+header file <code>gperftools/malloc_extension.h</code>.</p>
+
+<p>Here's an example, from an actual Google webserver, of what the
+output should look like:</p>
+<pre>
+heap profile:    741: 812122112 [   741: 812122112] @ growth
+     1:  1572864 [     1:  1572864] @ 0x87da564 0x87db8a3 0x84787a4 0x846e851 0x836d12f 0x834cd1c 0x8349ba5 0x10a3177 0x8349961
+     1:  1048576 [     1:  1048576] @ 0x87d92e8 0x87d9213 0x87d9178 0x87d94d3 0x87da9da 0x8a364ff 0x8a437e7 0x8ab7d23 0x8ab7da9 0x8ac7454 0x8348465 0x10a3161 0x8349961
+[...]
+</pre>
+
+
+<h2> <A NAME="profile"><code><b>/pprof/profile</b></code></A> </h2>
+
+<p><code>pprof</code> asks for the url
+<code>/pprof/profile?seconds=XX</code> to get cpu-profiling
+information.  The actual url is controlled via the variable
+<code>PROFILE_PAGE</code> in the <code>pprof</code> script, so you can
+change it if you'd like.</p>
+
+<p>The server should respond by calling
+<code>ProfilerStart(filename)</code>, continuing to do its work, and
+then, XX seconds later, calling <code>ProfilerStop()</code>.  (These
+functions are declared in <code>gperftools/profiler.h</code>.)  The
+application is responsible for picking a unique filename for
+<code>ProfilerStart()</code>.  After calling
+<code>ProfilerStop()</code>, the server should read the contents of
+<code>filename</code> and send them back as an HTTP response to
+<code>pprof</code>.</p>
+
+<p>Obviously, to get useful profile information the application must
+continue to run in the XX seconds that the profiler is running.  Thus,
+the profile start-stop calls should be done in a separate thread, or
+be otherwise non-blocking.</p>
+
+<p>The profiler output file is binary, but near the end of it, it
+should have lines of text somewhat like this:</p>
+<pre>
+01016000-01017000 rw-p 00015000 03:01 59314      /lib/ld-2.2.2.so
+</pre>
+
+<h2> <code><b>/pprof/pmuprofile</b></code> </h2>
+
+<code>pprof</code> asks for a url of the form
+<code>/pprof/pmuprofile?event=hw_event:unit_mask&period=nnn&seconds=xxx</code> 
+to get cpu-profiling information.  The actual url is controlled via the variable
+<code>PMUPROFILE_PAGE</code> in the <code>pprof</code> script, so you can
+change it if you'd like.</p> 
+
+<p>
+This is similar to pprof, but is meant to be used with your CPU's hardware 
+performance counters. The server could be implemented on top of a library 
+such as <a href="http://perfmon2.sourceforge.net/">
+<code>libpfm</code></a>. It should collect a sample every nnn occurrences 
+of the event and stop the sampling after xxx seconds. Much of the code 
+for <code>/pprof/profile</code> can be reused for this purpose.
+</p>
+
+<p>The server side routines (the equivalent of
+ProfilerStart/ProfilerStart) are not available as part of perftools,
+so this URL is unlikely to be that useful.</p>
+
+<h2> <code><b>/pprof/contention</b></code> </h2>
+
+<p>This is intended to be able to profile (thread) lock contention in
+addition to CPU and memory use.  It's not yet usable.</p>
+
+
+<h2> <code><b>/pprof/cmdline</b></code> </h2>
+
+<p><code>pprof</code> asks for the url <code>/pprof/cmdline</code> to
+figure out what application it's profiling.  The actual url is
+controlled via the variable <code>PROGRAM_NAME_PAGE</code> in the
+<code>pprof</code> script, so you can change it if you'd like.</p>
+
+<p>The server should respond by reading the contents of
+<code>/proc/self/cmdline</code>, converting all internal NUL (\0)
+characters to newlines, and sending the result back as an HTTP
+response to <code>pprof</code>.</p>
+
+<p>Here's an example return value:<p>
+<pre>
+/root/server/custom_webserver
+80
+--configfile=/root/server/ws.config
+</pre>
+
+
+<h2> <code><b>/pprof/symbol</b></code> </h2>
+
+<p><code>pprof</code> asks for the url <code>/pprof/symbol</code> to
+map from hex addresses to variable names.  The actual url is
+controlled via the variable <code>SYMBOL_PAGE</code> in the
+<code>pprof</code> script, so you can change it if you'd like.</p>
+
+<p>When the server receives a GET request for
+<code>/pprof/symbol</code>, it should return a line formatted like
+so:</p>
+<pre>
+   num_symbols: ###
+</pre>
+<p>where <code>###</code> is the number of symbols found in the
+binary.  (For now, the only important distinction is whether the value
+is 0, which it is for executables that lack debug information, or
+not-0).</p>
+
+<p>This is perhaps the hardest request to write code for, because in
+addition to the GET request for this url, the server must accept POST
+requests.  This means that after the HTTP headers, pprof will pass in
+a list of hex addresses connected by <code>+</code>, like so:</p>
+<pre>
+   curl -d '0x0824d061+0x0824d1cf' http://remote_host:80/pprof/symbol
+</pre>
+
+<p>The server should read the POST data, which will be in one line,
+and for each hex value, should write one line of output to the output
+stream, like so:</p>
+<pre>
+&lt;hex address&gt;&lt;tab&gt;&lt;function name&gt;
+</pre>
+<p>For instance:</p>
+<pre>
+0x08b2dabd    _Update
+</pre>
+
+<p>The other reason this is the most difficult request to implement,
+is that the application will have to figure out for itself how to map
+from address to function name.  One possibility is to run <code>nm -C
+-n &lt;program name&gt;</code> to get the mappings at
+program-compile-time.  Another, at least on Linux, is to call out to
+addr2line for every <code>pprof/symbol</code> call, for instance
+<code>addr2line -Cfse /proc/<getpid>/exe 0x12345678 0x876543210</code>
+(presumably with some caching!)</p>
+
+<p><code>pprof</code> itself does just this for local profiles (not
+ones that talk to remote servers); look at the subroutine
+<code>GetProcedureBoundaries</code>.</p>
+
+
+<hr>
+Last modified: Mon Jun 12 21:30:14 PDT 2006
+</body>
+</html>

--- a/tcmalloc.html
+++ b/tcmalloc.html
@@ -1,0 +1,779 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!-- $Id: $ -->
+<html>
+<head>
+<title>TCMalloc : Thread-Caching Malloc</title>
+<link rel="stylesheet" href="designstyle.css">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<style type="text/css">
+  em {
+    color: red;
+    font-style: normal;
+  }
+</style>
+</head>
+<body>
+
+<h1>TCMalloc : Thread-Caching Malloc</h1>
+
+<address>Sanjay Ghemawat</address>
+
+<h2><A name=motivation>Motivation</A></h2>
+
+<p>TCMalloc is faster than the glibc 2.3 malloc (available as a
+separate library called ptmalloc2) and other mallocs that I have
+tested.  ptmalloc2 takes approximately 300 nanoseconds to execute a
+malloc/free pair on a 2.8 GHz P4 (for small objects).  The TCMalloc
+implementation takes approximately 50 nanoseconds for the same
+operation pair.  Speed is important for a malloc implementation
+because if malloc is not fast enough, application writers are inclined
+to write their own custom free lists on top of malloc.  This can lead
+to extra complexity, and more memory usage unless the application
+writer is very careful to appropriately size the free lists and
+scavenge idle objects out of the free list.</p>
+
+<p>TCMalloc also reduces lock contention for multi-threaded programs.
+For small objects, there is virtually zero contention.  For large
+objects, TCMalloc tries to use fine grained and efficient spinlocks.
+ptmalloc2 also reduces lock contention by using per-thread arenas but
+there is a big problem with ptmalloc2's use of per-thread arenas.  In
+ptmalloc2 memory can never move from one arena to another.  This can
+lead to huge amounts of wasted space.  For example, in one Google
+application, the first phase would allocate approximately 300MB of
+memory for its URL canonicalization data structures.  When the first
+phase finished, a second phase would be started in the same address
+space.  If this second phase was assigned a different arena than the
+one used by the first phase, this phase would not reuse any of the
+memory left after the first phase and would add another 300MB to the
+address space.  Similar memory blowup problems were also noticed in
+other applications.</p>
+
+<p>Another benefit of TCMalloc is space-efficient representation of
+small objects.  For example, N 8-byte objects can be allocated while
+using space approximately <code>8N * 1.01</code> bytes.  I.e., a
+one-percent space overhead.  ptmalloc2 uses a four-byte header for
+each object and (I think) rounds up the size to a multiple of 8 bytes
+and ends up using <code>16N</code> bytes.</p>
+
+
+<h2><A NAME="Usage">Usage</A></h2>
+
+<p>To use TCMalloc, just link TCMalloc into your application via the
+"-ltcmalloc" linker flag.</p>
+
+<p>You can use TCMalloc in applications you didn't compile yourself,
+by using LD_PRELOAD:</p>
+<pre>
+   $ LD_PRELOAD="/usr/lib/libtcmalloc.so" <binary>
+</pre>
+<p>LD_PRELOAD is tricky, and we don't necessarily recommend this mode
+of usage.</p>
+
+<p>TCMalloc includes a <A HREF="heap_checker.html">heap checker</A>
+and <A HREF="heapprofile.html">heap profiler</A> as well.</p>
+
+<p>If you'd rather link in a version of TCMalloc that does not include
+the heap profiler and checker (perhaps to reduce binary size for a
+static binary), you can link in <code>libtcmalloc_minimal</code>
+instead.</p>
+
+
+<h2><A NAME="Overview">Overview</A></h2>
+
+<p>TCMalloc assigns each thread a thread-local cache.  Small
+allocations are satisfied from the thread-local cache.  Objects are
+moved from central data structures into a thread-local cache as
+needed, and periodic garbage collections are used to migrate memory
+back from a thread-local cache into the central data structures.</p>
+<center><img src="overview.gif"></center>
+
+<p>TCMalloc treats objects with size &lt;= 256K ("small" objects)
+differently from larger objects.  Large objects are allocated directly
+from the central heap using a page-level allocator (a page is a 8K
+aligned region of memory).  I.e., a large object is always
+page-aligned and occupies an integral number of pages.</p>
+
+<p>A run of pages can be carved up into a sequence of small objects,
+each equally sized.  For example a run of one page (4K) can be carved
+up into 32 objects of size 128 bytes each.</p>
+
+
+<h2><A NAME="Small_Object_Allocation">Small Object Allocation</A></h2>
+
+<p>Each small object size maps to one of approximately 88 allocatable
+size-classes.  For example, all allocations in the range 961 to 1024
+bytes are rounded up to 1024.  The size-classes are spaced so that
+small sizes are separated by 8 bytes, larger sizes by 16 bytes, even
+larger sizes by 32 bytes, and so forth.  The maximal spacing is
+controlled so that not too much space is wasted when an allocation
+request falls just past the end of a size class and has to be rounded
+up to the next class.</p>
+
+<p>A thread cache contains a singly linked list of free objects per
+size-class.</p>
+<center><img src="threadheap.gif"></center>
+
+<p>When allocating a small object: (1) We map its size to the
+corresponding size-class.  (2) Look in the corresponding free list in
+the thread cache for the current thread.  (3) If the free list is not
+empty, we remove the first object from the list and return it.  When
+following this fast path, TCMalloc acquires no locks at all.  This
+helps speed-up allocation significantly because a lock/unlock pair
+takes approximately 100 nanoseconds on a 2.8 GHz Xeon.</p>
+
+<p>If the free list is empty: (1) We fetch a bunch of objects from a
+central free list for this size-class (the central free list is shared
+by all threads).  (2) Place them in the thread-local free list.  (3)
+Return one of the newly fetched objects to the applications.</p>
+
+<p>If the central free list is also empty: (1) We allocate a run of
+pages from the central page allocator.  (2) Split the run into a set
+of objects of this size-class.  (3) Place the new objects on the
+central free list.  (4) As before, move some of these objects to the
+thread-local free list.</p>
+
+<h3><A NAME="Sizing_Thread_Cache_Free_Lists">
+  Sizing Thread Cache Free Lists</A></h3>
+
+<p>It is important to size the thread cache free lists correctly.  If
+the free list is too small, we'll need to go to the central free list
+too often.  If the free list is too big, we'll waste memory as objects
+sit idle in the free list.</p>
+
+<p>Note that the thread caches are just as important for deallocation
+as they are for allocation.  Without a cache, each deallocation would
+require moving the memory to the central free list.  Also, some threads
+have asymmetric alloc/free behavior (e.g. producer and consumer threads),
+so sizing the free list correctly gets trickier.</p>
+
+<p>To size the free lists appropriately, we use a slow-start algorithm
+to determine the maximum length of each individual free list.  As the
+free list is used more frequently, its maximum length grows.  However,
+if a free list is used more for deallocation than allocation, its
+maximum length will grow only up to a point where the whole list can
+be efficiently moved to the central free list at once.</p>
+
+<p>The psuedo-code below illustrates this slow-start algorithm.  Note
+that <code>num_objects_to_move</code> is specific to each size class.
+By moving a list of objects with a well-known length, the central
+cache can efficiently pass these lists between thread caches.  If
+a thread cache wants fewer than <code>num_objects_to_move</code>,
+the operation on the central free list has linear time complexity.
+The downside of always using <code>num_objects_to_move</code> as
+the number of objects to transfer to and from the central cache is
+that it wastes memory in threads that don't need all of those objects.
+
+<pre>
+Start each freelist max_length at 1.
+
+Allocation
+  if freelist empty {
+    fetch min(max_length, num_objects_to_move) from central list;
+    if max_length < num_objects_to_move {  // slow-start
+      max_length++;
+    } else {
+      max_length += num_objects_to_move;
+    }
+  }
+
+Deallocation
+  if length > max_length {
+    // Don't try to release num_objects_to_move if we don't have that many.
+    release min(max_length, num_objects_to_move) objects to central list
+    if max_length < num_objects_to_move {
+      // Slow-start up to num_objects_to_move.
+      max_length++;
+    } else if max_length > num_objects_to_move {
+      // If we consistently go over max_length, shrink max_length.
+      overages++;
+      if overages > kMaxOverages {
+        max_length -= num_objects_to_move;
+        overages = 0;
+      }
+    }
+  }
+</pre>
+
+See also the section on <a href="#Garbage_Collection">Garbage Collection</a>
+to see how it affects the <code>max_length</code>.
+
+<h2><A NAME="Medium_Object_Allocation">Medium Object Allocation</A></h2>
+
+<p>A medium object size (256K &le; size &le; 1MB) is rounded up to a page
+size (8K) and is handled by a central page heap. The central page heap
+includes an array of 128 free lists.  The <code>k</code>th entry is a
+free list of runs that consist of <code>k + 1</code> pages:</p>
+<center><img src="pageheap.gif"></center>
+
+<p>An allocation for <code>k</code> pages is satisfied by looking in
+the <code>k</code>th free list.  If that free list is empty, we look
+in the next free list, and so forth.  If no medium-object free list
+can satisfy the allocation, the allocation is treated as a large object.
+
+
+<h2><A NAME="Large_Object_Allocation">Large Object Allocation</A></h2>
+
+Allocations of 1MB or more are considered large allocations. Spans
+of free memory which can satisfy these allocations are tracked in
+a red-black tree sorted by size. Allocations follow the <em>best-fit</em>
+algorithm: the tree is searched to find the smallest span of free
+space which is larger than the requested allocation. The allocation
+is carved out of that span, and the remaining space is reinserted
+either into the large object tree or possibly into one of the smaller
+free-lists as appropriate.
+
+If no span of free memory is located that can fit the requested
+allocation, we fetch memory from the system (using <code>sbrk</code>,
+<code>mmap</code>, or by mapping in portions of
+<code>/dev/mem</code>).</p>
+
+<p>If an allocation for <code>k</code> pages is satisfied by a run
+of pages of length &gt; <code>k</code>, the remainder of the
+run is re-inserted back into the appropriate free list in the
+page heap.</p>
+
+
+<h2><A NAME="Spans">Spans</A></h2>
+
+<p>The heap managed by TCMalloc consists of a set of pages.  A run of
+contiguous pages is represented by a <code>Span</code> object.  A span
+can either be <em>allocated</em>, or <em>free</em>.  If free, the span
+is one of the entries in a page heap linked-list.  If allocated, it is
+either a large object that has been handed off to the application, or
+a run of pages that have been split up into a sequence of small
+objects.  If split into small objects, the size-class of the objects
+is recorded in the span.</p>
+
+<p>A central array indexed by page number can be used to find the span to
+which a page belongs.  For example, span <em>a</em> below occupies 2
+pages, span <em>b</em> occupies 1 page, span <em>c</em> occupies 5
+pages and span <em>d</em> occupies 3 pages.</p>
+<center><img src="spanmap.gif"></center>
+
+<p>In a 32-bit address space, the central array is represented by a a
+2-level radix tree where the root contains 32 entries and each leaf
+contains 2^14 entries (a 32-bit address space has 2^19 8K pages, and
+the first level of tree divides the 2^19 pages by 2^5).  This leads to
+a starting memory usage of 64KB of space (2^14*4 bytes) for the
+central array, which seems acceptable.</p>
+
+<p>On 64-bit machines, we use a 3-level radix tree.</p>
+
+
+<h2><A NAME="Deallocation">Deallocation</A></h2>
+
+<p>When an object is deallocated, we compute its page number and look
+it up in the central array to find the corresponding span object.  The
+span tells us whether or not the object is small, and its size-class
+if it is small.  If the object is small, we insert it into the
+appropriate free list in the current thread's thread cache.  If the
+thread cache now exceeds a predetermined size (2MB by default), we run
+a garbage collector that moves unused objects from the thread cache
+into central free lists.</p>
+
+<p>If the object is large, the span tells us the range of pages covered
+by the object.  Suppose this range is <code>[p,q]</code>.  We also
+lookup the spans for pages <code>p-1</code> and <code>q+1</code>.  If
+either of these neighboring spans are free, we coalesce them with the
+<code>[p,q]</code> span.  The resulting span is inserted into the
+appropriate free list in the page heap.</p>
+
+
+<h2>Central Free Lists for Small Objects</h2>
+
+<p>As mentioned before, we keep a central free list for each
+size-class.  Each central free list is organized as a two-level data
+structure: a set of spans, and a linked list of free objects per
+span.</p>
+
+<p>An object is allocated from a central free list by removing the
+first entry from the linked list of some span.  (If all spans have
+empty linked lists, a suitably sized span is first allocated from the
+central page heap.)</p>
+
+<p>An object is returned to a central free list by adding it to the
+linked list of its containing span.  If the linked list length now
+equals the total number of small objects in the span, this span is now
+completely free and is returned to the page heap.</p>
+
+
+<h2><A NAME="Garbage_Collection">Garbage Collection of Thread Caches</A></h2>
+
+<p>Garbage collecting objects from a thread cache keeps the size of
+the cache under control and returns unused objects to the central free
+lists.  Some threads need large caches to perform well while others
+can get by with little or no cache at all.  When a thread cache goes
+over its <code>max_size</code>, garbage collection kicks in and then the
+thread competes with the other threads for a larger cache.</p>
+
+<p>Garbage collection is run only during a deallocation.  We walk over
+all free lists in the cache and move some number of objects from the
+free list to the corresponding central list.</p>
+
+<p>The number of objects to be moved from a free list is determined
+using a per-list low-water-mark <code>L</code>.  <code>L</code>
+records the minimum length of the list since the last garbage
+collection.  Note that we could have shortened the list by
+<code>L</code> objects at the last garbage collection without
+requiring any extra accesses to the central list.  We use this past
+history as a predictor of future accesses and move <code>L/2</code>
+objects from the thread cache free list to the corresponding central
+free list.  This algorithm has the nice property that if a thread
+stops using a particular size, all objects of that size will quickly
+move from the thread cache to the central free list where they can be
+used by other threads.</p>
+
+<p>If a thread consistently deallocates more objects of a certain size
+than it allocates, this <code>L/2</code> behavior will cause at least
+<code>L/2</code> objects to always sit in the free list.  To avoid
+wasting memory this way, we shrink the maximum length of the freelist
+to converge on <code>num_objects_to_move</code> (see also
+<a href="#Sizing_Thread_Cache_Free_Lists">Sizing Thread Cache Free Lists</a>).
+
+<pre>
+Garbage Collection
+  if (L != 0 && max_length > num_objects_to_move) {
+    max_length = max(max_length - num_objects_to_move, num_objects_to_move)
+  }
+</pre>
+
+<p>The fact that the thread cache went over its <code>max_size</code> is
+an indication that the thread would benefit from a larger cache.  Simply
+increasing <code>max_size</code> would use an inordinate amount of memory
+in programs that have lots of active threads.  Developers can bound the
+memory used with the flag --tcmalloc_max_total_thread_cache_bytes.</p>
+
+<p>Each thread cache starts with a small <code>max_size</code>
+(e.g. 64KB) so that idle threads won't pre-allocate memory they don't
+need.  Each time the cache runs a garbage collection, it will also try
+to grow its <code>max_size</code>.  If the sum of the thread cache
+sizes is less than --tcmalloc_max_total_thread_cache_bytes,
+<code>max_size</code> grows easily.  If not, thread cache 1 will try
+to steal from thread cache 2 (picked round-robin) by decreasing thread
+cache 2's <code>max_size</code>.  In this way, threads that are more
+active will steal memory from other threads more often than they are
+have memory stolen from themselves.  Mostly idle threads end up with
+small caches and active threads end up with big caches.  Note that
+this stealing can cause the sum of the thread cache sizes to be
+greater than --tcmalloc_max_total_thread_cache_bytes until thread
+cache 2 deallocates some memory to trigger a garbage collection.</p>
+
+<h2><A NAME="performance">Performance Notes</A></h2>
+
+<h3>PTMalloc2 unittest</h3>
+
+<p>The PTMalloc2 package (now part of glibc) contains a unittest
+program <code>t-test1.c</code>. This forks a number of threads and
+performs a series of allocations and deallocations in each thread; the
+threads do not communicate other than by synchronization in the memory
+allocator.</p>
+
+<p><code>t-test1</code> (included in
+<code>tests/tcmalloc/</code>, and compiled as
+<code>ptmalloc_unittest1</code>) was run with a varying numbers of
+threads (1-20) and maximum allocation sizes (64 bytes -
+32Kbytes). These tests were run on a 2.4GHz dual Xeon system with
+hyper-threading enabled, using Linux glibc-2.3.2 from RedHat 9, with
+one million operations per thread in each test. In each case, the test
+was run once normally, and once with
+<code>LD_PRELOAD=libtcmalloc.so</code>.
+
+<p>The graphs below show the performance of TCMalloc vs PTMalloc2 for
+several different metrics. Firstly, total operations (millions) per
+elapsed second vs max allocation size, for varying numbers of
+threads. The raw data used to generate these graphs (the output of the
+<code>time</code> utility) is available in
+<code>t-test1.times.txt</code>.</p>
+
+<table>
+<tr>
+  <td><img src="tcmalloc-opspersec.vs.size.1.threads.png"></td>
+  <td><img src="tcmalloc-opspersec.vs.size.2.threads.png"></td>
+  <td><img src="tcmalloc-opspersec.vs.size.3.threads.png"></td>
+</tr>
+<tr>
+  <td><img src="tcmalloc-opspersec.vs.size.4.threads.png"></td>
+  <td><img src="tcmalloc-opspersec.vs.size.5.threads.png"></td>
+  <td><img src="tcmalloc-opspersec.vs.size.8.threads.png"></td>
+</tr>
+<tr>
+  <td><img src="tcmalloc-opspersec.vs.size.12.threads.png"></td>
+  <td><img src="tcmalloc-opspersec.vs.size.16.threads.png"></td>
+  <td><img src="tcmalloc-opspersec.vs.size.20.threads.png"></td>
+</tr>
+</table>
+
+
+<ul> 
+  <li> TCMalloc is much more consistently scalable than PTMalloc2 - for
+       all thread counts &gt;1 it achieves ~7-9 million ops/sec for small
+       allocations, falling to ~2 million ops/sec for larger
+       allocations. The single-thread case is an obvious outlier,
+       since it is only able to keep a single processor busy and hence
+       can achieve fewer ops/sec. PTMalloc2 has a much higher variance
+       on operations/sec - peaking somewhere around 4 million ops/sec
+       for small allocations and falling to &lt;1 million ops/sec for
+       larger allocations.
+
+  <li> TCMalloc is faster than PTMalloc2 in the vast majority of
+       cases, and particularly for small allocations. Contention
+       between threads is less of a problem in TCMalloc.
+
+  <li> TCMalloc's performance drops off as the allocation size
+       increases. This is because the per-thread cache is
+       garbage-collected when it hits a threshold (defaulting to
+       2MB). With larger allocation sizes, fewer objects can be stored
+       in the cache before it is garbage-collected.
+
+  <li> There is a noticeable drop in TCMalloc's performance at ~32K
+       maximum allocation size; at larger sizes performance drops less
+       quickly. This is due to the 32K maximum size of objects in the
+       per-thread caches; for objects larger than this TCMalloc
+       allocates from the central page heap.
+</ul>
+
+<p>Next, operations (millions) per second of CPU time vs number of
+threads, for max allocation size 64 bytes - 128 Kbytes.</p>
+
+<table>
+<tr>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.64.bytes.png"></td>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.256.bytes.png"></td>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.1024.bytes.png"></td>
+</tr>
+<tr>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.4096.bytes.png"></td>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.8192.bytes.png"></td>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.16384.bytes.png"></td>
+</tr>
+<tr>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.32768.bytes.png"></td>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.65536.bytes.png"></td>
+  <td><img src="tcmalloc-opspercpusec.vs.threads.131072.bytes.png"></td>
+</tr>
+</table>
+
+<p>Here we see again that TCMalloc is both more consistent and more
+efficient than PTMalloc2. For max allocation sizes &lt;32K, TCMalloc
+typically achieves ~2-2.5 million ops per second of CPU time with a
+large number of threads, whereas PTMalloc achieves generally 0.5-1
+million ops per second of CPU time, with a lot of cases achieving much
+less than this figure. Above 32K max allocation size, TCMalloc drops
+to 1-1.5 million ops per second of CPU time, and PTMalloc drops almost
+to zero for large numbers of threads (i.e. with PTMalloc, lots of CPU
+time is being burned spinning waiting for locks in the heavily
+multi-threaded case).</p>
+
+
+<H2><A NAME="runtime">Modifying Runtime Behavior</A></H2>
+
+<p>You can more finely control the behavior of the tcmalloc via
+environment variables.</p>
+
+<p>Generally useful flags:</p>
+
+<table frame=box rules=cols cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>TCMALLOC_SAMPLE_PARAMETER</code></td>
+  <td>default: 0</td>
+  <td>
+    The approximate gap between sampling actions.  That is, we
+    take one sample approximately once every
+    <code>tcmalloc_sample_parmeter</code> bytes of allocation.
+    This sampled heap information is available via
+    <code>MallocExtension::GetHeapSample()</code> or
+    <code>MallocExtension::ReadStackTraces()</code>.  A reasonable
+    value is 524288.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_RELEASE_RATE</code></td>
+  <td>default: 1.0</td>
+  <td>
+    Rate at which we release unused memory to the system, via
+    <code>madvise(MADV_DONTNEED)</code>, on systems that support
+    it.  Zero means we never release memory back to the system.
+    Increase this flag to return memory faster; decrease it
+    to return memory slower.  Reasonable rates are in the
+    range [0,10].
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD</code></td>
+  <td>default: 1073741824</td>
+  <td>
+    Allocations larger than this value cause a stack trace to be
+    dumped to stderr.  The threshold for dumping stack traces is
+    increased by a factor of 1.125 every time we print a message so
+    that the threshold automatically goes up by a factor of ~1000
+    every 60 messages.  This bounds the amount of extra logging
+    generated by this flag.  Default value of this flag is very large
+    and therefore you should see no extra logging unless the flag is
+    overridden.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES</code></td>
+  <td>default: 16777216</td>
+  <td>
+    Bound on the total amount of bytes allocated to thread caches.  This
+    bound is not strict, so it is possible for the cache to go over this
+    bound in certain circumstances.  This value defaults to 16MB.  For
+    applications with many threads, this may not be a large enough cache,
+    which can affect performance.  If you suspect your application is not
+    scaling to many threads due to lock contention in TCMalloc, you can
+    try increasing this value.  This may improve performance, at a cost
+    of extra memory use by TCMalloc.  See <a href="#Garbage_Collection">
+    Garbage Collection</a> for more details.
+  </td>
+</tr>
+
+</table>
+
+<p>Advanced "tweaking" flags, that control more precisely how tcmalloc
+tries to allocate memory from the kernel.</p>
+
+<table frame=box rules=cols cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>TCMALLOC_SKIP_MMAP</code></td>
+  <td>default: false</td>
+  <td>
+     If true, do not try to use <code>mmap</code> to obtain memory
+     from the kernel.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_SKIP_SBRK</code></td>
+  <td>default: false</td>
+  <td>
+     If true, do not try to use <code>sbrk</code> to obtain memory
+     from the kernel.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_DEVMEM_START</code></td>
+  <td>default: 0</td>
+  <td>
+    Physical memory starting location in MB for <code>/dev/mem</code>
+    allocation.  Setting this to 0 disables <code>/dev/mem</code>
+    allocation.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_DEVMEM_LIMIT</code></td>
+  <td>default: 0</td>
+  <td>
+     Physical memory limit location in MB for <code>/dev/mem</code>
+     allocation.  Setting this to 0 means no limit.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_DEVMEM_DEVICE</code></td>
+  <td>default: /dev/mem</td>
+  <td>
+     Device to use for allocating unmanaged memory.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_MEMFS_MALLOC_PATH</code></td>
+  <td>default: ""</td>
+  <td>
+     If set, specify a path where hugetlbfs or tmpfs is mounted.
+     This may allow for speedier allocations.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_MEMFS_LIMIT_MB</code></td>
+  <td>default: 0</td>
+  <td>
+     Limit total memfs allocation size to specified number of MB.
+     0 means "no limit".
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_MEMFS_ABORT_ON_FAIL</code></td>
+  <td>default: false</td>
+  <td>
+     If true, abort() whenever memfs_malloc fails to satisfy an allocation.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_MEMFS_IGNORE_MMAP_FAIL</code></td>
+  <td>default: false</td>
+  <td>
+     If true, ignore failures from mmap.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>TCMALLOC_MEMFS_MAP_PRIVATE</code></td>
+  <td>default: false</td>
+  <td>
+     If true, use MAP_PRIVATE when mapping via memfs, not MAP_SHARED.
+  </td>
+</tr>
+
+</table>
+
+
+<H2><A NAME="compiletime">Modifying Behavior In Code</A></H2>
+
+<p>The <code>MallocExtension</code> class, in
+<code>malloc_extension.h</code>, provides a few knobs that you can
+tweak in your program, to affect tcmalloc's behavior.</p>
+
+<h3>Releasing Memory Back to the System</h3>
+
+<p>By default, tcmalloc will release no-longer-used memory back to the
+kernel gradually, over time.  The <a
+href="#runtime">tcmalloc_release_rate</a> flag controls how quickly
+this happens.  You can also force a release at a given point in the
+progam execution like so:</p>
+<pre>
+   MallocExtension::instance()->ReleaseFreeMemory();
+</pre>
+
+<p>You can also call <code>SetMemoryReleaseRate()</code> to change the
+<code>tcmalloc_release_rate</code> value at runtime, or
+<code>GetMemoryReleaseRate</code> to see what the current release rate
+is.</p>
+
+<h3>Memory Introspection</h3>
+
+<p>There are several routines for getting a human-readable form of the
+current memory usage:</p>
+<pre>
+   MallocExtension::instance()->GetStats(buffer, buffer_length);
+   MallocExtension::instance()->GetHeapSample(&string);
+   MallocExtension::instance()->GetHeapGrowthStacks(&string);
+</pre>
+
+<p>The last two create files in the same format as the heap-profiler,
+and can be passed as data files to pprof.  The first is human-readable
+and is meant for debugging.</p>
+
+<h3>Generic Tcmalloc Status</h3>
+
+<p>TCMalloc has support for setting and retrieving arbitrary
+'properties':</p>
+<pre>
+   MallocExtension::instance()->SetNumericProperty(property_name, value);
+   MallocExtension::instance()->GetNumericProperty(property_name, &value);
+</pre>
+
+<p>It is possible for an application to set and get these properties,
+but the most useful is when a library sets the properties so the
+application can read them.  Here are the properties TCMalloc defines;
+you can access them with a call like
+<code>MallocExtension::instance()->GetNumericProperty("generic.heap_size",
+&value);</code>:</p>
+
+<table frame=box rules=cols cellpadding=5 width=100%>
+
+<tr valign=top>
+  <td><code>generic.current_allocated_bytes</code></td>
+  <td>
+    Number of bytes used by the application.  This will not typically
+    match the memory use reported by the OS, because it does not
+    include TCMalloc overhead or memory fragmentation.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>generic.heap_size</code></td>
+  <td>
+    Bytes of system memory reserved by TCMalloc.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>tcmalloc.pageheap_free_bytes</code></td>
+  <td>
+    Number of bytes in free, mapped pages in page heap.  These bytes
+    can be used to fulfill allocation requests.  They always count
+    towards virtual memory usage, and unless the underlying memory is
+    swapped out by the OS, they also count towards physical memory
+    usage.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>tcmalloc.pageheap_unmapped_bytes</code></td>
+  <td>
+    Number of bytes in free, unmapped pages in page heap.  These are
+    bytes that have been released back to the OS, possibly by one of
+    the MallocExtension "Release" calls.  They can be used to fulfill
+    allocation requests, but typically incur a page fault.  They
+    always count towards virtual memory usage, and depending on the
+    OS, typically do not count towards physical memory usage.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>tcmalloc.slack_bytes</code></td>
+  <td>
+    Sum of pageheap_free_bytes and pageheap_unmapped_bytes.  Provided
+    for backwards compatibility only.  Do not use.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>tcmalloc.max_total_thread_cache_bytes</code></td>
+  <td>
+    A limit to how much memory TCMalloc dedicates for small objects.
+    Higher numbers trade off more memory use for -- in some situations
+    -- improved efficiency.
+  </td>
+</tr>
+
+<tr valign=top>
+  <td><code>tcmalloc.current_total_thread_cache_bytes</code></td>
+  <td>
+    A measure of some of the memory TCMalloc is using (for
+    small objects).
+  </td>
+</tr>
+
+</table>
+
+<h2><A NAME="caveats">Caveats</A></h2>
+
+<p>For some systems, TCMalloc may not work correctly with
+applications that aren't linked against <code>libpthread.so</code> (or
+the equivalent on your OS). It should work on Linux using glibc 2.3,
+but other OS/libc combinations have not been tested.</p>
+
+<p>TCMalloc may be somewhat more memory hungry than other mallocs,
+(but tends not to have the huge blowups that can happen with other
+mallocs).  In particular, at startup TCMalloc allocates approximately
+240KB of internal memory.</p>
+
+<p>Don't try to load TCMalloc into a running binary (e.g., using JNI
+in Java programs).  The binary will have allocated some objects using
+the system malloc, and may try to pass them to TCMalloc for
+deallocation.  TCMalloc will not be able to handle such objects.</p>
+
+<hr>
+
+<address>Sanjay Ghemawat, Paul Menage<br>
+<!-- Created: Tue Dec 19 10:43:14 PST 2000 -->
+<!-- hhmts start -->
+Last modified: Sat Feb 24 13:11:38 PST 2007  (csilvers)
+<!-- hhmts end -->
+</address>
+
+</body>
+</html>


### PR DESCRIPTION
Correct grammar, HTML, include installation instructions and correct the execution instructions (gperftools package uses google-pprof by default, not pprof (tau).