### PR TITLE
Fix uninitialized memory use in sampler_test

### DIFF
--- a/src/tests/sampler_test.cc
+++ b/src/tests/sampler_test.cc
@@ -361,7 +361,7 @@ double StandardDeviationsErrorInSample(
 }
 
 TEST(Sampler, LargeAndSmallAllocs_CombinedTest) {
-  tcmalloc::Sampler sampler;
+  tcmalloc::Sampler sampler{0, 0, false};
   sampler.Init(1);
   int counter_big = 0;
   int counter_small = 0;


### PR DESCRIPTION
Sampler's documentation states the following:
  C++03 requires that types stored in TLS be POD.  As a result, you must
  initialize these members to {0, 0, false} before using this class!

However, the test code wasn't doing that. MemorySanitizer and
UndefinedBehaviorSanitizer both failed because of it.