### PR TITLE
Add doubly linked free lists for thread caches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -437,6 +437,7 @@ S_TCMALLOC_MINIMAL_INCLUDES = src/common.h \
                               src/pagemap.h \
                               src/sampler.h \
                               src/central_freelist.h \
+                              src/free_list.h \
                               src/linked_list.h \
                               src/libc_override.h \
                               src/libc_override_gcc_and_weak.h \
@@ -470,6 +471,7 @@ libtcmalloc_minimal_internal_la_SOURCES = src/common.cc \
                                           $(SYSTEM_ALLOC_CC) \
                                           src/memfs_malloc.cc \
                                           src/central_freelist.cc \
+                                          src/free_list.cc \
                                           src/page_heap.cc \
                                           src/sampler.cc \
                                           src/span.cc \
@@ -796,13 +798,15 @@ if WITH_DEBUGALLOC
 
 lib_LTLIBRARIES += libtcmalloc_minimal_debug.la
 libtcmalloc_minimal_debug_la_SOURCES = src/debugallocation.cc \
-                                       $(TCMALLOC_MINIMAL_INCLUDES)
+                                       $(libtcmalloc_minimal_internal_la_SOURCES)
 libtcmalloc_minimal_debug_la_CXXFLAGS = $(libtcmalloc_minimal_la_CXXFLAGS) \
-                                        -DTCMALLOC_FOR_DEBUGALLOCATION
+                                        -DNO_HEAP_CHECK \
+                                        -DTCMALLOC_FOR_DEBUGALLOCATION \
+                                        -DTCMALLOC_USE_DOUBLYLINKED_FREELIST
 # version_info gets passed to libtool
 libtcmalloc_minimal_debug_la_LDFLAGS = $(libtcmalloc_minimal_la_LDFLAGS) \
                                        -version-info @TCMALLOC_SO_VERSION@
-libtcmalloc_minimal_debug_la_LIBADD = $(libtcmalloc_minimal_la_LIBADD)
+libtcmalloc_minimal_debug_la_LIBADD = $(LIBSPINLOCK) libmaybe_threads.la
 
 LIBS_TO_WEAKEN += libtcmalloc_minimal_debug.la
 
@@ -1207,13 +1211,22 @@ if WITH_DEBUGALLOC
 if WITH_HEAP_PROFILER_OR_CHECKER
 
 lib_LTLIBRARIES += libtcmalloc_debug.la
-libtcmalloc_debug_la_SOURCES = src/debugallocation.cc $(HEAP_CHECKER_SOURCES) \
-                               $(TCMALLOC_INCLUDES)
+libtcmalloc_debug_la_SOURCES = src/debugallocation.cc \
+                               $(HEAP_CHECKER_SOURCES) \
+                               $(libtcmalloc_minimal_internal_la_SOURCES) \
+                               $(TCMALLOC_INCLUDES) \
+                               src/base/low_level_alloc.cc \
+                               src/heap-profile-table.cc \
+                               src/heap-profiler.cc \
+                               src/raw_printer.cc \
+                               $(EMERGENCY_MALLOC_CC) \
+                               src/memory_region_map.cc
 libtcmalloc_debug_la_CXXFLAGS = $(libtcmalloc_la_CXXFLAGS) \
-                                -DTCMALLOC_FOR_DEBUGALLOCATION
+                                -DTCMALLOC_FOR_DEBUGALLOCATION \
+                                -DTCMALLOC_USE_DOUBLYLINKED_FREELIST
 libtcmalloc_debug_la_LDFLAGS = $(libtcmalloc_la_LDFLAGS) \
                                -version-info @TCMALLOC_SO_VERSION@
-libtcmalloc_debug_la_LIBADD = $(libtcmalloc_la_LIBADD)
+libtcmalloc_debug_la_LIBADD = libstacktrace.la libmaybe_threads.la $(PTHREAD_LIBS)
 
 LIBS_TO_WEAKEN += libtcmalloc_debug.la
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -136,7 +136,7 @@ void SizeMap::Init() {
   int sc = 1;   // Next size class to assign
   int alignment = kAlignment;
   CHECK_CONDITION(kAlignment <= kMinAlign);
-  for (size_t size = kAlignment; size <= kMaxSize; size += alignment) {
+  for (size_t size = kMinClassSize; size <= kMaxSize; size += alignment) {
     alignment = AlignmentForSize(size);
     CHECK_CONDITION((size % alignment) == 0);
 

--- a/src/free_list.cc
+++ b/src/free_list.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2011, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// ---
+// Author: Rebecca Shapiro <bxx@google.com>
+//
+// This file contains functions that implement doubly linked and
+// singly linked lists.  The singly linked lists are null terminated,
+// use raw pointers to link neighboring elements, and these pointers
+// are stored at the start of each element, independently of the
+// elements's size.  Because pointers are stored within each element,
+// each element must be large enough to store two raw pointers if
+// doubly linked lists are employed, or one raw pointer if singly
+// linked lists are employed.  On machines with 64 bit pointers, this
+// means elements must be at least 16 bytes in size for doubly linked
+// list support, and 8 bytes for singly linked list support.  No
+// attempts are made to preserve the data in elements stored in the
+// list.
+//
+// Given a machine with pointers of size N (on a 64bit machine N=8, on
+// a 32bit machine, N=4), the list pointers are stored in the
+// following manner:
+// -In doubly linked lists, the |next| pointer is stored in the first N
+// bytes of the node and the |previous| pointer is writtend into the
+// second N bytes.
+// -In singly linked lists, the |next| pointer is stored in the first N
+// bytes of the node.
+//
+// For both types of lists: when a pop operation is performed on a non
+// empty list, the new list head becomes that which is pointed to by
+// the former head's |next| pointer.  If the list is doubly linked, the
+// new head |previous| pointer gets changed from pointing to the former
+// head to NULL.
+
+#include "free_list.h"
+#include <stddef.h>
+#include <limits>
+
+#if defined(TCMALLOC_USE_DOUBLYLINKED_FREELIST)
+
+namespace tcmalloc {
+
+// Remove |n| elements from linked list at whose first element is at
+// |*head|.  |head| will be modified to point to the new head.
+// |start| will point to the first node of the range, |end| will point
+// to the last node in the range. |n| must be <= FL_Size(|*head|)
+// If |n| > 0, |head| must not be NULL.
+void FL_PopRange(void** head, int n, void** start, void** end) {
+  if (n == 0) {
+    *start = NULL;
+    *end = NULL;
+    return;
+  }
+
+  *start = *head;  // Remember the first node in the range.
+  void* tmp = *head;
+  for (int i = 1; i < n; ++i) {  // Find end of range.
+    tmp = FL_Next(tmp);
+  }
+  *end = tmp;  // |end| now set to point to last node in range.
+  *head = FL_Next(*end);
+  FL_SetNext(*end, NULL);  // Unlink range from list.
+
+  if (*head) {  // Fixup popped list.
+    FL_SetPrevious(*head, NULL);
+  }
+}
+
+// Pushes the nodes in the list beginning at |start| whose last node
+// is |end| into the linked list at |*head|. |*head| is updated to
+// point be the new head of the list.  |head| must not be NULL.
+void FL_PushRange(void** head, void* start, void* end) {
+  if (!start)
+    return;
+
+  // Sanity checking of ends of list to push is done by calling
+  // FL_Next and FL_Previous.
+  FL_Next(start);
+  FL_Previous(end);
+  ASSERT(FL_Previous_No_Check(start) == NULL);
+  ASSERT(FL_Next_No_Check(end) == NULL);
+
+  if (*head) {
+    FL_EqualityCheck(FL_Previous_No_Check(*head), (void*)NULL, __FILE__,
+                     __LINE__);
+    FL_SetNext(end, *head);
+    FL_SetPrevious(*head, end);
+  }
+  *head = start;
+}
+
+// Calculates the size of the list that begins at |head|.
+size_t FL_Size(void* head) {
+  int count = 0;
+  if (head) {
+    FL_EqualityCheck(FL_Previous_No_Check(head), (void*)NULL, __FILE__,
+                     __LINE__);
+  }
+  while (head) {
+    count++;
+    head = FL_Next(head);
+  }
+  return count;
+}
+
+}  // namespace tcmalloc
+
+#endif  // TCMALLOC_USE_DOUBLYLINKED_FREELIST

--- a/src/free_list.h
+++ b/src/free_list.h
@@ -1,0 +1,210 @@
+// Copyright (c) 2011, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// ---
+// Author: Rebecca Shapiro <bxx@google.com>
+//
+// This file contains declarations of functions that implement doubly
+// linked lists and definitions of functions that implement singly
+// linked lists.  It also contains macros to tell the SizeMap class
+// how much space a node in the freelist needs so that SizeMap can
+// create large enough size classes.
+
+#ifndef TCMALLOC_FREE_LIST_H_
+#define TCMALLOC_FREE_LIST_H_
+
+#include <stddef.h>
+#include "internal_logging.h"
+#include "linked_list.h"
+#include "system-alloc.h"
+
+namespace tcmalloc {
+
+#if defined(TCMALLOC_USE_DOUBLYLINKED_FREELIST)
+
+// size class information for common.h.
+static const bool kSupportsDoublyLinkedList = true;
+
+void FL_PopRange(void** head, int n, void** start, void** end);
+void FL_PushRange(void** head, void* start, void* end);
+size_t FL_Size(void* head);
+
+template <typename T>
+inline void FL_EqualityCheck(const T& v0,
+                             const T& v1,
+                             const char* file,
+                             int line) {
+  if (v0 != v1)
+    Log(kCrash, file, line, "Memory corruption detected.");
+}
+
+inline void EnsureNonLoop(void* node, void* next) {
+  // We only have time to do minimal checking.  We don't traverse the list, but
+  // only look for an immediate loop (cycle back to ourself).
+  if (node != next)
+    return;
+  Log(kCrash, __FILE__, __LINE__, "Circular loop in list detected: ", next);
+}
+
+inline void* MaskPtr(void* p) {
+  // Maximize ASLR entropy and guarantee the result is an invalid address.
+  const uintptr_t mask =
+      ~(reinterpret_cast<uintptr_t>(TCMalloc_SystemAlloc) >> 13);
+  return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(p) ^ mask);
+}
+
+inline void* UnmaskPtr(void* p) {
+  return MaskPtr(p);
+}
+
+// Returns value of the |previous| pointer w/out running a sanity
+// check.
+inline void* FL_Previous_No_Check(void* t) {
+  return UnmaskPtr(reinterpret_cast<void**>(t)[1]);
+}
+
+// Returns value of the |next| pointer w/out running a sanity check.
+inline void* FL_Next_No_Check(void* t) {
+  return UnmaskPtr(reinterpret_cast<void**>(t)[0]);
+}
+
+inline void* FL_Previous(void* t) {
+  void* previous = FL_Previous_No_Check(t);
+  if (previous) {
+    FL_EqualityCheck(FL_Next_No_Check(previous), t, __FILE__, __LINE__);
+  }
+  return previous;
+}
+
+inline void FL_SetPrevious(void* t, void* n) {
+  EnsureNonLoop(t, n);
+  reinterpret_cast<void**>(t)[1] = MaskPtr(n);
+}
+
+inline void FL_SetNext(void* t, void* n) {
+  EnsureNonLoop(t, n);
+  reinterpret_cast<void**>(t)[0] = MaskPtr(n);
+}
+
+inline void* FL_Next(void* t) {
+  void* next = FL_Next_No_Check(t);
+  if (next) {
+    FL_EqualityCheck(FL_Previous_No_Check(next), t, __FILE__, __LINE__);
+  }
+  return next;
+}
+
+// Pops the top element off the linked list whose first element is at
+// |*list|, and updates |*list| to point to the next element in the
+// list.  Returns the address of the element that was removed from the
+// linked list.  |list| must not be NULL.
+inline void* FL_Pop(void** list) {
+  void* result = *list;
+  ASSERT(FL_Previous_No_Check(result) == NULL);
+  *list = FL_Next(result);
+  if (*list != NULL) {
+    FL_SetPrevious(*list, NULL);
+  }
+  return result;
+}
+
+// Makes the element at |t| a singleton doubly linked list.
+inline void FL_Init(void* t) {
+  FL_SetPrevious(t, NULL);
+  FL_SetNext(t, NULL);
+}
+
+// Pushes element to a linked list whose first element is at
+// |*list|. When this call returns, |list| will point to the new head
+// of the linked list.
+inline void FL_Push(void** list, void* element) {
+  void* old = *list;
+  if (old == NULL) {  // Builds singleton list.
+    FL_Init(element);
+  } else {
+    ASSERT(FL_Previous_No_Check(old) == NULL);
+    FL_SetNext(element, old);
+    FL_SetPrevious(old, element);
+    FL_SetPrevious(element, NULL);
+  }
+  *list = element;
+}
+
+#else  // TCMALLOC_USE_DOUBLYLINKED_FREELIST not defined
+static const bool kSupportsDoublyLinkedList = false;
+
+inline void* FL_Next(void* t) {
+  return SLL_Next(t);
+}
+
+inline void FL_Init(void* t) {
+  SLL_SetNext(t, NULL);
+}
+
+inline void FL_Push(void** list, void* element) {
+  if (*list != element) {
+    SLL_Push(list, element);
+    return;
+  }
+  Log(kCrash, __FILE__, __LINE__, "Double Free of %p detected", element);
+}
+
+inline void* FL_Pop(void** list) {
+  return SLL_Pop(list);
+}
+
+inline void FL_SetPrevious(void* t, void* n) {
+  // Singly linked list has no previous element.
+}
+
+inline void FL_SetNext(void* t, void* n) {
+  SLL_SetNext(t, n);
+}
+
+// Removes |N| elements from a linked list to which |head| points.
+// |head| will be modified to point to the new |head|.  |start| and
+// |end| will point to the first and last nodes of the range.  Note
+// that |end| will point to NULL after this function is called.
+inline void FL_PopRange(void** head, int n, void** start, void** end) {
+  SLL_PopRange(head, n, start, end);
+}
+
+inline void FL_PushRange(void** head, void* start, void* end) {
+  SLL_PushRange(head, start, end);
+}
+
+inline size_t FL_Size(void* head) {
+  return SLL_Size(head);
+}
+
+#endif  // TCMALLOC_USE_DOUBLYLINKED_FREELIST
+
+}  // namespace tcmalloc
+
+#endif  // TCMALLOC_FREE_LIST_H_

--- a/src/page_heap_allocator.h
+++ b/src/page_heap_allocator.h
@@ -37,6 +37,7 @@
 #include <stddef.h>                     // for NULL, size_t
 
 #include "common.h"            // for MetaDataAlloc
+#include "free_list.h"         // for FL_Push/FL_Pop
 #include "internal_logging.h"  // for ASSERT
 
 namespace tcmalloc {
@@ -63,8 +64,7 @@ class PageHeapAllocator {
     // Consult free list
     void* result;
     if (free_list_ != NULL) {
-      result = free_list_;
-      free_list_ = *(reinterpret_cast<void**>(result));
+      result = FL_Pop(&free_list_);
     } else {
       if (free_avail_ < sizeof(T)) {
         // Need more room. We assume that MetaDataAlloc returns
@@ -87,8 +87,7 @@ class PageHeapAllocator {
   }
 
   void Delete(T* p) {
-    *(reinterpret_cast<void**>(p)) = free_list_;
-    free_list_ = p;
+    FL_Push(&free_list_, p);
     inuse_--;
   }
 

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -121,8 +121,8 @@
 #include "base/spinlock.h"              // for SpinLockHolder
 #include "central_freelist.h"  // for CentralFreeListPadded
 #include "common.h"            // for StackTrace, kPageShift, etc
+#include "free_list.h"         // for FL_Init
 #include "internal_logging.h"  // for ASSERT, TCMalloc_Printer, etc
-#include "linked_list.h"       // for SLL_SetNext
 #include "malloc_hook-inl.h"       // for MallocHook::InvokeNewHook, etc
 #include "page_heap.h"         // for PageHeap, PageHeap::Stats
 #include "page_heap_allocator.h"  // for PageHeapAllocator
@@ -1484,7 +1484,7 @@ void do_free_with_callback(void* ptr,
   }
 
   // Otherwise, delete directly into central cache
-  tcmalloc::SLL_SetNext(ptr, NULL);
+  tcmalloc::FL_Init(ptr);
   Static::central_cache()[cl].InsertRange(ptr, ptr, 1);
 }
 

--- a/src/thread_cache.cc
+++ b/src/thread_cache.cc
@@ -133,7 +133,10 @@ void* ThreadCache::FetchFromCentralCache(uint32 cl, int32_t byte_size,
 
   if (--fetch_count >= 0) {
     size_ += byte_size * fetch_count;
-    list->PushRange(fetch_count, SLL_Next(start), end);
+    // Pop the top of the list and add the rest to the freelist.
+    void* second = start;
+    start = FL_Pop(&second);
+    list->PushRange(fetch_count, second, end);
   }
 
   // Increase max length slowly up to batch_size.  After that,


### PR DESCRIPTION
By default, it is enabled when debug allocation is enabled, but it can be manually enabled by defining TCMALLOC_USE_DOUBLYLINKED_FREELIST.

Also fixed the macro name used in the Makefile to denote debug allocation is enabled.
