### PR TITLE
tcmalloc: add a guard page in front of metadata allocations

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -288,9 +288,9 @@ class SizeMap {
   }
 };
 
-// Allocates "bytes" worth of memory and returns it.  Increments
-// metadata_system_bytes appropriately.  May return NULL if allocation
-// fails.  Requires pageheap_lock is held.
+// Allocates "bytes" worth of memory with a guard page in front and
+// returns it.  Increments metadata_system_bytes appropriately.  May
+// return NULL if allocation fails.  Requires pageheap_lock is held.
 void* MetaDataAlloc(size_t bytes);
 
 // Returns the total number of bytes allocated from the system.

--- a/src/system-alloc.h
+++ b/src/system-alloc.h
@@ -83,6 +83,10 @@ bool TCMalloc_SystemRelease(void* start, size_t length);
 extern PERFTOOLS_DLL_DECL
 void TCMalloc_SystemCommit(void* start, size_t length);
 
+// Guards the first page in the supplied range of memory. It crashes the
+// program if the guard page cannot be added.
+extern void TCMalloc_SystemAddGuard(void* start, size_t size);
+
 // The current system allocator.
 extern PERFTOOLS_DLL_DECL SysAllocator* tcmalloc_sys_alloc;
 


### PR DESCRIPTION
Based on original CL:
- https://codereview.chromium.org/8570023

  Add a guard page in front of metadata allocations.

  BUG=104752
  Committed:
  http://src.chromium.org/viewvc/chrome?view=rev&revision=112260

Code has been modified to create the guard page inside MetaDataAlloc,
once per 8MB chunk.

Reviewed-on: https://chromium-review.googlesource.com/c/1130794