### PR TITLE
Add generic.total_physical_bytes property to MallocExtension

### DIFF
--- a/src/gperftools/malloc_extension.h
+++ b/src/gperftools/malloc_extension.h
@@ -168,6 +168,14 @@ class PERFTOOLS_DLL_DECL MallocExtension {
   //            freed memory regions
   //      This property is not writable.
   //
+  //  "generic.total_physical_bytes"
+  //      Estimate of total bytes of the physical memory usage by the
+  //      allocator ==
+  //            current_allocated_bytes +
+  //            fragmentation +
+  //            metadata
+  //      This property is not writable.
+  //
   // tcmalloc
   // --------
   // "tcmalloc.max_total_thread_cache_bytes"

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -711,6 +711,14 @@ class TCMallocImplementation : public MallocExtension {
       return true;
     }
 
+    if (strcmp(name, "generic.total_physical_bytes") == 0) {
+      TCMallocStats stats;
+      ExtractStats(&stats, NULL, NULL, NULL);
+      *value = stats.pageheap.system_bytes + stats.metadata_bytes -
+               stats.pageheap.unmapped_bytes;
+      return true;
+    }
+
     if (strcmp(name, "tcmalloc.slack_bytes") == 0) {
       // Kept for backwards compatibility.  Now defined externally as:
       //    pageheap_free_bytes + pageheap_unmapped_bytes.


### PR DESCRIPTION
Original CL:

- https://codereview.chromium.org/1410353005

  Add generic.total_physical_bytes property to MallocExtension

  The actual physical memory usage of tcmalloc cannot be obtained by
  GetNumericProperty. This accounts for the current_allocated_bytes,
  fragmentation and malloc metadata, and excludes the unmapped memory
  regions. This helps the user to understand how much memory is actually
  being used for the allocations that were made.

Reviewed-on: https://chromium-review.googlesource.com/1130803