### PR TITLE
Return early in WriteProfile to reduce indentation

### DIFF
--- a/src/heap-profile-table.cc
+++ b/src/heap-profile-table.cc
@@ -440,22 +440,20 @@ bool HeapProfileTable::WriteProfile(const char* file_name,
                                     AllocationMap* allocations) {
   RAW_VLOG(1, "Dumping non-live heap profile to %s", file_name);
   RawFD fd = RawOpenForWriting(file_name);
-  if (fd != kIllegalRawFD) {
-    RawWrite(fd, kProfileHeader, strlen(kProfileHeader));
-    char buf[512];
-    int len = UnparseBucket(total, buf, 0, sizeof(buf), " heapprofile",
-                            NULL);
-    RawWrite(fd, buf, len);
-    const DumpArgs args(fd, NULL);
-    allocations->Iterate<const DumpArgs&>(DumpNonLiveIterator, args);
-    RawWrite(fd, kProcSelfMapsHeader, strlen(kProcSelfMapsHeader));
-    DumpProcSelfMaps(fd);
-    RawClose(fd);
-    return true;
-  } else {
+  if (fd == kIllegalRawFD) {
     RAW_LOG(ERROR, "Failed dumping filtered heap profile to %s", file_name);
     return false;
   }
+  RawWrite(fd, kProfileHeader, strlen(kProfileHeader));
+  char buf[512];
+  int len = UnparseBucket(total, buf, 0, sizeof(buf), " heapprofile", NULL);
+  RawWrite(fd, buf, len);
+  const DumpArgs args(fd, NULL);
+  allocations->Iterate<const DumpArgs&>(DumpNonLiveIterator, args);
+  RawWrite(fd, kProcSelfMapsHeader, strlen(kProcSelfMapsHeader));
+  DumpProcSelfMaps(fd);
+  RawClose(fd);
+  return true;
 }
 
 void HeapProfileTable::CleanupOldProfiles(const char* prefix) {


### PR DESCRIPTION
Small code refactoring to reduce indentation. This change was originally
part of https://codereview.chromium.org/9963095.

Reviewed-on: https://chromium-review.googlesource.com/c/1130804