### PR TITLE
Fix mmap region iteration while no regions are recorded.

### DIFF
--- a/src/memory_region_map.cc
+++ b/src/memory_region_map.cc
@@ -234,6 +234,9 @@ void MemoryRegionMap::Init(int max_stack_depth, bool use_buckets) {
     memset(bucket_table_, 0, table_bytes);
     num_buckets_ = 0;
   }
+  if (regions_ == NULL) {  // init regions_
+    InitRegionSetLocked();
+  }
   Unlock();
   RAW_VLOG(10, "MemoryRegionMap Init done");
 }
@@ -536,6 +539,15 @@ void MemoryRegionMap::RestoreSavedBucketsLocked() {
   }
 }
 
+inline void MemoryRegionMap::InitRegionSetLocked() {
+  RAW_VLOG(12, "Initializing region set");
+  regions_ = regions_rep.region_set();
+  recursive_insert = true;
+  new (regions_) RegionSet();
+  HandleSavedRegionsLocked(&DoInsertRegionLocked);
+  recursive_insert = false;
+}
+
 inline void MemoryRegionMap::InsertRegionLocked(const Region& region) {
   RAW_CHECK(LockIsHeld(), "should be held (by this thread)");
   // We can be called recursively, because RegionSet constructor
@@ -556,12 +568,7 @@ inline void MemoryRegionMap::InsertRegionLocked(const Region& region) {
     saved_regions[saved_regions_count++] = region;
   } else {  // not a recusrive call
     if (regions_ == NULL) {  // init regions_
-      RAW_VLOG(12, "Initializing region set");
-      regions_ = regions_rep.region_set();
-      recursive_insert = true;
-      new(regions_) RegionSet();
-      HandleSavedRegionsLocked(&DoInsertRegionLocked);
-      recursive_insert = false;
+      InitRegionSetLocked();
     }
     recursive_insert = true;
     // Do the actual insertion work to put new regions into regions_:

--- a/src/memory_region_map.h
+++ b/src/memory_region_map.h
@@ -362,6 +362,9 @@ class MemoryRegionMap {
   // table where all buckets eventually should be.
   static void RestoreSavedBucketsLocked();
 
+  // Initialize RegionSet regions_.
+  inline static void InitRegionSetLocked();
+
   // Wrapper around DoInsertRegionLocked
   // that handles the case of recursive allocator calls.
   inline static void InsertRegionLocked(const Region& region);


### PR DESCRIPTION
If no mmap regions are recorded, iteration failed since the RegionSet
(std::set) object is not initialized.

Original CL https://codereview.chromium.org/14769008

Reviewed-on: https://chromium-review.googlesource.com/c/1130807