### PR TITLE
add option to disable benchmarks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -858,6 +858,7 @@ endif WITH_STACK_TRACE
 
 endif WITH_DEBUGALLOC
 
+if WITH_BENCHMARKS
 if !MINGW
 noinst_LTLIBRARIES += librun_benchmark.la
 librun_benchmark_la_SOURCES = \
@@ -910,6 +911,7 @@ binary_trees_shared_CXXFLAGS = $(PTHREAD_CFLAGS) $(AM_CXXFLAGS) $(NO_BUILTIN_CXX
 binary_trees_shared_LDFLAGS = $(PTHREAD_CFLAGS) $(TCMALLOC_FLAGS)
 binary_trees_shared_LDADD = libtcmalloc_minimal.la $(PTHREAD_LIBS)
 endif !MINGW
+endif WITH_BENCHMARKS
 
 ### ------- tcmalloc (thread-caching malloc + heap profiler + heap checker)
 

--- a/configure.ac
+++ b/configure.ac
@@ -462,6 +462,14 @@ AC_ARG_ENABLE([emergency-malloc],
 
 AM_CONDITIONAL(BUILD_EMERGENCY_MALLOC, [test "x$enable_emergency_malloc" = xyes])
 
+AC_ARG_WITH([benchmarks],
+            [AS_HELP_STRING([--without-benchmarks],
+                            [do not build benchmarks])],
+            [],
+            [with_benchmarks=yes])
+
+AM_CONDITIONAL(WITH_BENCHMARKS, [test "x$with_benchmarks" = xyes])
+
 # Defines PRIuS
 AC_COMPILER_CHARACTERISTICS
 


### PR DESCRIPTION
unwind_bench uses getcontext function however it is not available on
musl (POSIX.1-2004 obsoleted this function and in POSIX.1-2008 it was
removed) so add --without-benchmarks option.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>