### PR TITLE
undef mmap64 function

### DIFF
--- a/src/malloc_hook_mmap_linux.h
+++ b/src/malloc_hook_mmap_linux.h
@@ -137,7 +137,8 @@ static inline void* do_mmap64(void *start, size_t length,
 // malloc_hook section,
 // so that MallocHook::GetCallerStackTrace can function accurately:
 
-// Make sure mmap doesn't get #define'd away by <sys/mman.h>
+// Make sure mmap64 and mmap doesn't get #define'd away by <sys/mman.h>
+# undef mmap64
 # undef mmap
 
 extern "C" {


### PR DESCRIPTION
mmap64 can already been defined and as a result the following error is
raised:

In file included from src/malloc_hook.cc:686:0:
src/malloc_hook_mmap_linux.h: In function ‘void* mmap(void*, size_t, int, int, int, off_t)’:
src/malloc_hook_mmap_linux.h:173:18: error: redefinition of ‘void* mmap(void*, size_t, int, int, int, off_t)’
 extern "C" void* mmap(void *start, size_t length, int prot, int flags,
                  ^~~~
In file included from src/malloc_hook.cc:41:0:
src/malloc_hook_mmap_linux.h:159:18: note: ‘void* mmap(void*, size_t, int, int, int, off_t)’ previously defined here
 extern "C" void* mmap64(void *start, size_t length, int prot, int flags,
                  ^
Makefile:4874: recipe for target 'src/libtcmalloc_minimal_internal_la-malloc_hook.lo' failed

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>