### PR TITLE
Allow configuring page size to 4K, 8K, 16K, 32K, 64K, 128K and 256K

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -113,8 +113,9 @@ To build libtcmalloc with large pages you need to use the
 
    ./configure <other flags> --with-tcmalloc-pagesize=32
 
-The ARG argument can be 8, 32 or 64 which sets the internal page size to
-8K, 32K and 64K repectively. The default is 8K.
+The ARG argument can be 4, 8, 16, 32, 64, 128 or 256 which sets the
+internal page size to 4K, 8K, 16K, 32K, 64K, 128K and 256K respectively.
+The default is 8K.
 
 
 *** SMALL TCMALLOC CACHES: TRADING SPACE FOR TIME

--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_ARG_ENABLE([libunwind],
               [enable_libunwind="$default_enable_libunwind"])
 AC_ARG_WITH([tcmalloc-pagesize],
             [AS_HELP_STRING([--with-tcmalloc-pagesize],
-                            [Set the tcmalloc internal page size to 8K, 32K or 64K])],
+                            [Set the tcmalloc internal page size to 4K, 8K, 16K, 32K, 64K, 128K or 256K])],
             [],
             [with_tcmalloc_pagesize=$default_tcmalloc_pagesize])
 AC_ARG_WITH([tcmalloc-alignment],
@@ -119,15 +119,22 @@ AC_ARG_WITH([tcmalloc-alignment],
             [with_tcmalloc_alignment=$default_tcmalloc_alignment])
 
 case "$with_tcmalloc_pagesize" in
+  4)
+       AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 12);;
   8)
        #Default tcmalloc page size.
        ;;
+  16)
+       AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 14);;
   32)
-       AC_DEFINE(TCMALLOC_32K_PAGES, 1,
-                 [Define 32K of internal pages size for tcmalloc]);;
+       AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 15);;
   64)
-       AC_DEFINE(TCMALLOC_64K_PAGES, 1,
-                 [Define 64K of internal pages size for tcmalloc]);;
+       AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 16);;
+  128)
+       AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 17);;
+  256)
+       AC_DEFINE(TCMALLOC_PAGE_SIZE_SHIFT, 18,
+                 [Define internal page size for tcmalloc as number of left bitshift]);;
   *)
        AC_MSG_WARN([${with_tcmalloc_pagesize}K size not supported, using default tcmalloc page size.])
 esac

--- a/src/common.h
+++ b/src/common.h
@@ -78,7 +78,7 @@ static const size_t kPageShift  = TCMALLOC_PAGE_SIZE_SHIFT;
 static const size_t kPageShift  = 13;
 #endif
 
-static const size_t kClassSizesMax = 96;
+static const size_t kClassSizesMax = 128;
 
 static const size_t kMaxThreadCacheSize = 4 << 20;
 

--- a/src/common.h
+++ b/src/common.h
@@ -72,10 +72,8 @@ static const size_t kMinAlign   = 16;
 // the thread cache allowance to avoid passing more free ranges to and from
 // central lists.  Also, larger pages are less likely to get freed.
 // These two factors cause a bounded increase in memory use.
-#if defined(TCMALLOC_32K_PAGES)
-static const size_t kPageShift  = 15;
-#elif defined(TCMALLOC_64K_PAGES)
-static const size_t kPageShift  = 16;
+#if defined(TCMALLOC_PAGE_SIZE_SHIFT)
+static const size_t kPageShift  = TCMALLOC_PAGE_SIZE_SHIFT;
 #else
 static const size_t kPageShift  = 13;
 #endif

--- a/src/windows/config.h
+++ b/src/windows/config.h
@@ -320,14 +320,11 @@
 /* the namespace where STL code like vector<> is defined */
 #define STL_NAMESPACE std
 
-/* Define 32K of internal pages size for tcmalloc */
-/* #undef TCMALLOC_32K_PAGES */
-
-/* Define 64K of internal pages size for tcmalloc */
-/* #undef TCMALLOC_64K_PAGES */
-
 /* Define 8 bytes of allocation alignment for tcmalloc */
 /* #undef TCMALLOC_ALIGN_8BYTES */
+
+/* Define internal page size for tcmalloc as number of left bitshift */
+/* #undef TCMALLOC_PAGE_SIZE_SHIFT */
 
 /* Version number of package */
 #define VERSION "2.7"


### PR DESCRIPTION
As talked about in #1079 I'm unsure how you edit config.h for Windows, but I manually mirrored the changes in config.h from ./configure
Set the lowest allowed page size to 4K, do you want to allow smaller than that?