### PR TITLE
Fix a clang-tidy readability warning for static member access

### DIFF
--- a/src/thread_cache.cc
+++ b/src/thread_cache.cc
@@ -278,7 +278,7 @@ void ThreadCache::IncreaseCacheLimitLocked() {
 }
 
 int ThreadCache::GetSamplePeriod() {
-  return sampler_.GetSamplePeriod();
+  return Sampler::GetSamplePeriod();
 }
 
 void ThreadCache::InitModule() {


### PR DESCRIPTION
This fixes the following warning:

src/thread_cache.cc:281:10: warning: static member accessed through instance [readability-static-accessed-through-instance]
  return sampler_.GetSamplePeriod();
         ^~~~~~~~~~~~~~~~~~~~~~~~
         tcmalloc::Sampler::