### PR TITLE
Add Safe-Linking to Single-Linked-Lists (SLL)

### DIFF
--- a/src/base/basictypes.h
+++ b/src/base/basictypes.h
@@ -120,9 +120,11 @@ const  int64 kint64min =  ( (((uint64) kint32min) << 32) | 0 );
 #if defined(__GNUC__)
 #define PREDICT_TRUE(x) __builtin_expect(!!(x), 1)
 #define PREDICT_FALSE(x) __builtin_expect(!!(x), 0)
+#define UNREACHABLE __builtin_unreachable();
 #else
 #define PREDICT_TRUE(x) (x)
 #define PREDICT_FALSE(x) (x)
+#define UNREACHABLE
 #endif
 
 // A macro to disallow the evil copy constructor and operator= functions

--- a/src/internal_logging.h
+++ b/src/internal_logging.h
@@ -109,8 +109,9 @@ extern PERFTOOLS_DLL_DECL void (*log_message_writer)(const char* msg, int length
 #undef CHECK_CONDITION
 #define CHECK_CONDITION(cond)                                            \
 do {                                                                     \
-  if (!(cond)) {                                                         \
+  if (PREDICT_FALSE(!(cond))) {                                          \
     ::tcmalloc::Log(::tcmalloc::kCrash, __FILE__, __LINE__, #cond);      \
+    UNREACHABLE;                                                         \
   }                                                                      \
 } while (0)
 

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -38,15 +38,26 @@
 #define TCMALLOC_LINKED_LIST_H_
 
 #include <stddef.h>
+#include "common.h"
+
+// Safe-Linking:
+// Use randomness from ASLR (mmap_base) to protect the single-linked
+// lists used by the heap. Together with allocation alignment checks,
+// this mechanism reduces the risk of pointer hijacking, similarly to
+// the Safe-Unlinking in the double-linked lists of dlmalloc / ptmalloc.
+#define PROTECT_PTR(pos, ptr)     reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(pos) >> kPageShift) ^ reinterpret_cast<uintptr_t>(ptr))
+#define REVEAL_PTR(pos, ptr)      PROTECT_PTR(pos, ptr)
 
 namespace tcmalloc {
 
 inline void *SLL_Next(void *t) {
-  return *(reinterpret_cast<void**>(t));
+  void * result = REVEAL_PTR(t, *(reinterpret_cast<void**>(t)));
+  CHECK_CONDITION((reinterpret_cast<uintptr_t>(result) % kAlignment) == 0);
+  return result;
 }
 
 inline void SLL_SetNext(void *t, void *n) {
-  *(reinterpret_cast<void**>(t)) = n;
+  *(reinterpret_cast<void**>(t)) = PROTECT_PTR(t, n);
 }
 
 inline void SLL_Push(void **list, void *element) {

--- a/src/thread_cache.h
+++ b/src/thread_cache.h
@@ -226,7 +226,7 @@ class ThreadCache {
     }
 
     void* Next() {
-      return SLL_Next(&list_);
+      return SLL_Next(list_);
     }
 
     void PushRange(int N, void *start, void *end) {
@@ -390,7 +390,7 @@ inline ATTRIBUTE_ALWAYS_INLINE void ThreadCache::Deallocate(void* ptr, uint32 cl
   // This catches back-to-back frees of allocs in the same size
   // class. A more comprehensive (and expensive) test would be to walk
   // the entire freelist. But this might be enough to find some bugs.
-  ASSERT(ptr != list->Next());
+  ASSERT(list->empty() || ptr != list->Next());
 
   uint32_t length = list->Push(ptr);
 


### PR DESCRIPTION
Safe-Linking is a security mechanism that protects single-linked
lists (such as the Free Lists) from being tampered by attackers. The
mechanism makes use of randomness from ASLR (```mmap_base```), and when
combined with object alignment integrity checks, it protects the
pointers from being hijacked by an attacker.

While Safe-Unlinking protects double-linked lists (such as the Small
Bins in ptmalloc), there wasn't any similar protection for attacks
against single-linked lists. This solution protects against three
common attacks:
  * Partial pointer override: Modified the lower bytes (Little Endian)
  * Full pointer override: Hijacks the pointer to an attacker's location
  * Unaligned objects: pointing the list to an unaligned address

The design assumes an attacker doesn't know where the heap is located,
and uses the ASLR randomness to "sign" the single-linked pointers. We
mark the pointer as P and the location in which it is stored as L, and
the calculation will be:
```PROTECT(P) := (L >> PAGE_SHIFT) XOR (P)```
```*L = PROTECT(P)```

This way, the random bits from the address L (which start at the bits
in the PAGE_SHIFT position), will be merged with the LSB of the stored
protected pointer. This protection layer prevents an attacker from
modifying the pointer into a controlled value.

An additional check that the objects are kAligned adds an important
layer:
  * Attackers can't point to illegal (unaligned) memory address
  * Attackers must guess correctly the alignment bits

Due to kAlignment being 8, an attacker will be directly fail 7 out of 8
times. And this could be improved in the future if the alignment will
match the class size, per Free List.

This proposed patch was benchmarked and on the worst test case it has
an additional overhead of 1.5%, while the overhead for the average test
case was a negligible 0.02%. In addition, in 2013 a similar mitigation
was incorporated into Chromium's Free List (FL) implementation in their
version of TCMalloc (branched out from gperftools 2.0). According to
Chromium's documentation, the added overhead was less than 2%.

For more information, feel free to read our full white-paper:
https://drive.google.com/open?id=1nDg38lfpPKJUSI6czrcgc14obtN6KEu5