### PR TITLE
Fix the removed std::allocator::pointer member type removed in C++20

### DIFF
--- a/src/tests/heap-checker_unittest.cc
+++ b/src/tests/heap-checker_unittest.cc
@@ -787,9 +787,9 @@ template<class Alloc>
 static void DirectTestSTLAlloc(Alloc allocator, const char* name) {
   HeapLeakChecker check((string("direct_stl-") + name).c_str());
   static const int kSize = 1000;
-  typename Alloc::pointer ptrs[kSize];
+  typename Alloc::value_type* ptrs[kSize];
   for (int i = 0; i < kSize; ++i) {
-    typename Alloc::pointer p = allocator.allocate(i*3+1);
+    typename Alloc::value_type* p = allocator.allocate(i*3+1);
     HeapLeakChecker::IgnoreObject(p);
     // This will crash if p is not known to heap profiler:
     // (i.e. STL's "allocator" does not have a direct hook to heap profiler)


### PR DESCRIPTION
This member type was deprecated in C++17 and removed in C++20.