### PR TITLE
New ProfilerGetStackTrace()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1313,7 +1313,7 @@ libprofiler_la_SOURCES = src/profiler.cc \
                          $(CPU_PROFILER_INCLUDES)
 libprofiler_la_LIBADD = libstacktrace.la libmaybe_threads.la libfake_stacktrace_scope.la
 # We have to include ProfileData for profiledata_unittest
-CPU_PROFILER_SYMBOLS = '(ProfilerStart|ProfilerStartWithOptions|ProfilerStop|ProfilerFlush|ProfilerEnable|ProfilerDisable|ProfilingIsEnabledForAllThreads|ProfilerRegisterThread|ProfilerGetCurrentState|ProfilerState|ProfileData|ProfileHandler)'
+CPU_PROFILER_SYMBOLS = '(ProfilerStart|ProfilerStartWithOptions|ProfilerStop|ProfilerFlush|ProfilerEnable|ProfilerDisable|ProfilingIsEnabledForAllThreads|ProfilerRegisterThread|ProfilerGetCurrentState|ProfilerState|ProfileData|ProfileHandler|ProfilerGetStackTrace)'
 libprofiler_la_LDFLAGS = -export-symbols-regex $(CPU_PROFILER_SYMBOLS) \
                          -version-info @PROFILER_SO_VERSION@
 

--- a/src/gperftools/profiler.h
+++ b/src/gperftools/profiler.h
@@ -162,6 +162,10 @@ struct ProfilerState {
 };
 PERFTOOLS_DLL_DECL void ProfilerGetCurrentState(struct ProfilerState* state);
 
+/* Returns the current stack trace, to be called from a SIGPROF handler. */
+PERFTOOLS_DLL_DECL int ProfilerGetStackTrace(
+    void** result, int max_depth, int skip_count, const void *uc);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -402,6 +402,11 @@ extern "C" PERFTOOLS_DLL_DECL void ProfilerGetCurrentState(
   CpuProfiler::instance_.GetCurrentState(state);
 }
 
+extern "C" PERFTOOLS_DLL_DECL int ProfilerGetStackTrace(
+    void** result, int max_depth, int skip_count, const void *uc) {
+  return GetStackTraceWithContext(result, max_depth, skip_count, uc);
+}
+
 #else  // OS_CYGWIN
 
 // ITIMER_PROF doesn't work under cygwin.  ITIMER_REAL is available, but doesn't
@@ -419,6 +424,10 @@ extern "C" int ProfilerStartWithOptions(const char *fname,
 extern "C" void ProfilerStop() { }
 extern "C" void ProfilerGetCurrentState(ProfilerState* state) {
   memset(state, 0, sizeof(*state));
+}
+extern "C" int ProfilerGetStackTrace(
+    void** result, int max_depth, int skip_count, const void *uc) {
+  return 0;
 }
 
 #endif  // OS_CYGWIN


### PR DESCRIPTION
Properly exported function that wraps `GetStackTraceWithContext()`, as discussed in #1004.

Closes #948.

@alk: I can't update #1004, let's continue discussion here.