### PR TITLE
Increase kMaxStackDepth to 256

### DIFF
--- a/src/profiledata.h
+++ b/src/profiledata.h
@@ -101,7 +101,7 @@ class ProfileData {
     int      frequency_;                  // Sample frequency.
   };
 
-  static const int kMaxStackDepth = 64;  // Max stack depth stored in profile
+  static const int kMaxStackDepth = 256;  // Max stack depth stored in profile
 
   ProfileData();
   ~ProfileData();


### PR DESCRIPTION
Some programs may have a stack depth of over 64. I encountered this issue when debugging a C++ module that was being called from a Python program—the Python call stack occupied most of the 64 frames and I couldn't see what was happening in C++.

Increasing kMaxStackDepth to 256 is more than enough for the use case described above and Ought To Be Enough For Anybody™. This should have a negligible effect on memory usage if the program doesn't actually use more than 64 frames.

Fixes https://github.com/gperftools/gperftools/issues/1194 .