### PR TITLE
Add OS X arm64 program counter

### DIFF
--- a/m4/pc_from_ucontext.m4
+++ b/m4/pc_from_ucontext.m4
@@ -43,6 +43,7 @@ AC_DEFUN([AC_PC_FROM_UCONTEXT],
    pc_fields="$pc_fields uc_mcontext->__ss.__rip"      # OS X (>=10.5 [untested])
    pc_fields="$pc_fields uc_mcontext->ss.srr0"         # OS X (ppc, ppc64 [untested])
    pc_fields="$pc_fields uc_mcontext->__ss.__srr0"     # OS X (>=10.5 [untested])
+   pc_fields="$pc_fields uc_mcontext->__ss.__pc"       # OS X (arm64 [untested])
    pc_field_found=false
    for pc_field in $pc_fields; do
      if ! $pc_field_found; then


### PR DESCRIPTION
When building gperftools on OSX Big Sur (11.0.1) on the M1 processor (arm64) I saw the below message and the profiler was not built. 

> Could not find the PC.  Will not try to compile libprofiler...

To fix this I added the program counter that I could find on my machine.