### PR TITLE
syscall: Mark x8 as clobbered on arm64

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -2223,7 +2223,7 @@ struct kernel_stat {
                                 "svc 0x0\n"                                   \
                                 : "=r"(__res_x0)                              \
                                 : "i"(__NR_##name) , ## args                  \
-                                : "memory");                                  \
+                                : "x8", "memory");                            \
           __res = __res_x0;                                                   \
           LSS_RETURN(type, __res)
     #undef _syscall0
@@ -2340,7 +2340,7 @@ struct kernel_stat {
                                "r"(__fn), "r"(__stack), "r"(__flags), "r"(__arg),
                                "r"(__ptid), "r"(__tls), "r"(__ctid),
                                "i"(__NR_clone), "i"(__NR_exit)
-                             : "x30", "memory");
+                             : "x8", "x30", "memory");
       }
       LSS_RETURN(int, __res);
     }


### PR DESCRIPTION
Mark arm64 register x8 as clobbered by syscall body inline assembly as
it is being used to store the syscall number. Otherwise the compiler
may try to use it for some other purpose.

This fix is derived from a resolution to clang Bugzilla report
https://bugs.llvm.org/show_bug.cgi?id=48798.  See this report for a
minimal reproducer derived from the code fixed here as well as the
resolution.

This should fix SEGFAULTs as reported in
https://github.com/envoyproxy/envoy/issues/14756.

Fixes: #1241
Signed-off-by: Jarno Rajahalme <jarno@covalent.io>