### PR TITLE
atomicops: Remove Acquire_Store / Release_Load

### DIFF
--- a/src/base/atomicops-internals-arm-generic.h
+++ b/src/base/atomicops-internals-arm-generic.h
@@ -122,11 +122,6 @@ inline void MemoryBarrier() {
   pLinuxKernelMemoryBarrier();
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
   MemoryBarrier();
   *ptr = value;
@@ -140,11 +135,6 @@ inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
   Atomic32 value = *ptr;
   MemoryBarrier();
   return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 
@@ -185,10 +175,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
   NotImplementedFatalError("NoBarrier_Store");
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  NotImplementedFatalError("Acquire_Store64");
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   NotImplementedFatalError("Release_Store");
 }
@@ -200,11 +186,6 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
 
 inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
   NotImplementedFatalError("Atomic64 Acquire_Load");
-  return 0;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  NotImplementedFatalError("Atomic64 Release_Load");
   return 0;
 }
 

--- a/src/base/atomicops-internals-arm-v6plus.h
+++ b/src/base/atomicops-internals-arm-v6plus.h
@@ -136,11 +136,6 @@ inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
   MemoryBarrier();
   *ptr = value;
@@ -154,11 +149,6 @@ inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
   Atomic32 value = *ptr;
   MemoryBarrier();
   return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 // 64-bit versions are only available if LDREXD and STREXD instructions
@@ -288,11 +278,6 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
 
 #endif // BASE_ATOMICOPS_HAS_LDREXD_AND_STREXD
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  NoBarrier_Store(ptr, value);
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   MemoryBarrier();
   NoBarrier_Store(ptr, value);
@@ -302,11 +287,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
   Atomic64 value = NoBarrier_Load(ptr);
   MemoryBarrier();
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
-  return NoBarrier_Load(ptr);
 }
 
 inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,

--- a/src/base/atomicops-internals-gcc.h
+++ b/src/base/atomicops-internals-gcc.h
@@ -99,11 +99,6 @@ inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
   MemoryBarrier();
   *ptr = value;
@@ -117,11 +112,6 @@ inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
   Atomic32 value = *ptr;
   MemoryBarrier();
   return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 // 64-bit versions
@@ -172,11 +162,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   MemoryBarrier();
   *ptr = value;
@@ -190,11 +175,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
   Atomic64 value = *ptr;
   MemoryBarrier();
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 }  // namespace base::subtle

--- a/src/base/atomicops-internals-linuxppc.h
+++ b/src/base/atomicops-internals-linuxppc.h
@@ -359,14 +359,6 @@ inline void NoBarrier_Store(volatile Atomic32 *ptr, Atomic32 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic32 *ptr, Atomic32 value) {
-  *ptr = value;
-  // This can't be _lwsync(); we need to order the immediately
-  // preceding stores against any load that may follow, but lwsync
-  // doesn't guarantee that.
-  _sync();
-}
-
 inline void Release_Store(volatile Atomic32 *ptr, Atomic32 value) {
   _lwsync();
   *ptr = value;
@@ -382,28 +374,12 @@ inline Atomic32 Acquire_Load(volatile const Atomic32 *ptr) {
   return value;
 }
 
-inline Atomic32 Release_Load(volatile const Atomic32 *ptr) {
-  // This can't be _lwsync(); we need to order the immediately
-  // preceding stores against any load that may follow, but lwsync
-  // doesn't guarantee that.
-  _sync();
-  return *ptr;
-}
-
 #ifdef __PPC64__
 
 // 64-bit Versions.
 
 inline void NoBarrier_Store(volatile Atomic64 *ptr, Atomic64 value) {
   *ptr = value;
-}
-
-inline void Acquire_Store(volatile Atomic64 *ptr, Atomic64 value) {
-  *ptr = value;
-  // This can't be _lwsync(); we need to order the immediately
-  // preceding stores against any load that may follow, but lwsync
-  // doesn't guarantee that.
-  _sync();
 }
 
 inline void Release_Store(volatile Atomic64 *ptr, Atomic64 value) {
@@ -419,14 +395,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64 *ptr) {
   Atomic64 value = *ptr;
   _lwsync();
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64 *ptr) {
-  // This can't be _lwsync(); we need to order the immediately
-  // preceding stores against any load that may follow, but lwsync
-  // doesn't guarantee that.
-  _sync();
-  return *ptr;
 }
 
 #endif

--- a/src/base/atomicops-internals-macosx.h
+++ b/src/base/atomicops-internals-macosx.h
@@ -172,11 +172,6 @@ inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic32 *ptr, Atomic32 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic32 *ptr, Atomic32 value) {
   MemoryBarrier();
   *ptr = value;
@@ -190,11 +185,6 @@ inline Atomic32 Acquire_Load(volatile const Atomic32 *ptr) {
   Atomic32 value = *ptr;
   MemoryBarrier();
   return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32 *ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 // 64-bit version
@@ -268,11 +258,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic64 *ptr, Atomic64 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64 *ptr, Atomic64 value) {
   MemoryBarrier();
   *ptr = value;
@@ -286,11 +271,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64 *ptr) {
   Atomic64 value = *ptr;
   MemoryBarrier();
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64 *ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 #else
@@ -342,11 +322,6 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
 #endif
 
 
-inline void Acquire_Store(volatile Atomic64 *ptr, Atomic64 value) {
-  NoBarrier_Store(ptr, value);
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64 *ptr, Atomic64 value) {
   MemoryBarrier();
   NoBarrier_Store(ptr, value);
@@ -358,10 +333,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64 *ptr) {
   return value;
 }
 
-inline Atomic64 Release_Load(volatile const Atomic64 *ptr) {
-  MemoryBarrier();
-  return NoBarrier_Load(ptr);
-}
 #endif  // __LP64__
 
 }   // namespace base::subtle

--- a/src/base/atomicops-internals-mips.h
+++ b/src/base/atomicops-internals-mips.h
@@ -161,12 +161,6 @@ inline Atomic32 Release_AtomicExchange(volatile Atomic32* ptr,
     return NoBarrier_AtomicExchange(ptr, new_value);
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value)
-{
-    *ptr = value;
-    MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value)
 {
     MemoryBarrier();
@@ -183,12 +177,6 @@ inline Atomic32 Acquire_Load(volatile const Atomic32* ptr)
     Atomic32 value = *ptr;
     MemoryBarrier();
     return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32* ptr)
-{
-    MemoryBarrier();
-    return *ptr;
 }
 
 #if (_MIPS_ISA == _MIPS_ISA_MIPS64) || (_MIPS_SIM == _MIPS_SIM_ABI64)
@@ -285,12 +273,6 @@ inline Atomic64 Release_AtomicExchange(volatile Atomic64* ptr,
     return NoBarrier_AtomicExchange(ptr, new_value);
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value)
-{
-    *ptr = value;
-    MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value)
 {
     MemoryBarrier();
@@ -307,12 +289,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr)
     Atomic64 value = *ptr;
     MemoryBarrier();
     return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr)
-{
-    MemoryBarrier();
-    return *ptr;
 }
 
 #endif

--- a/src/base/atomicops-internals-windows.h
+++ b/src/base/atomicops-internals-windows.h
@@ -188,10 +188,6 @@ inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  Acquire_AtomicExchange(ptr, value);
-}
-
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
   *ptr = value; // works w/o barrier for current Intel chips as of June 2005
   // See comments in Atomic64 version of Release_Store() below.
@@ -204,11 +200,6 @@ inline Atomic32 NoBarrier_Load(volatile const Atomic32* ptr) {
 inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
   Atomic32 value = *ptr;
   return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 // 64-bit operations
@@ -298,11 +289,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  NoBarrier_AtomicExchange(ptr, value);
-              // acts as a barrier in this implementation
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   *ptr = value; // works w/o barrier for current Intel chips as of June 2005
 
@@ -321,11 +307,6 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
 inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
   Atomic64 value = *ptr;
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 #else  // defined(_WIN64) || defined(__MINGW64__)
@@ -393,11 +374,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptrValue, Atomic64 value)
   	}
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  NoBarrier_AtomicExchange(ptr, value);
-              // acts as a barrier in this implementation
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   NoBarrier_Store(ptr, value);
 }
@@ -417,11 +393,6 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptrValue)
 inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
   Atomic64 value = NoBarrier_Load(ptr);
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
-  return NoBarrier_Load(ptr);
 }
 
 #endif  // defined(_WIN64) || defined(__MINGW64__)

--- a/src/base/atomicops-internals-x86.h
+++ b/src/base/atomicops-internals-x86.h
@@ -128,11 +128,6 @@ inline void MemoryBarrier() {
   __asm__ __volatile__("mfence" : : : "memory");
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 #else
 
 inline void MemoryBarrier() {
@@ -144,14 +139,6 @@ inline void MemoryBarrier() {
   }
 }
 
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  if (AtomicOps_Internalx86CPUFeatures.has_sse2) {
-    *ptr = value;
-    __asm__ __volatile__("mfence" : : : "memory");
-  } else {
-    Acquire_AtomicExchange(ptr, value);
-  }
-}
 #endif
 
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
@@ -169,11 +156,6 @@ inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
   // See comments in Atomic64 version of Release_Store(), below.
   ATOMICOPS_COMPILER_BARRIER();
   return value;
-}
-
-inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 #if defined(__x86_64__)
@@ -216,11 +198,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
   *ptr = value;
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  *ptr = value;
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   ATOMICOPS_COMPILER_BARRIER();
 
@@ -252,11 +229,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
                          // See also Release_Store(), above.
   ATOMICOPS_COMPILER_BARRIER();
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
-  return *ptr;
 }
 
 #else // defined(__x86_64__)
@@ -333,11 +305,6 @@ inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
                          "mm2", "mm3", "mm4", "mm5", "mm6", "mm7");
 }
 
-inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
-  NoBarrier_Store(ptr, value);
-  MemoryBarrier();
-}
-
 inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
   ATOMICOPS_COMPILER_BARRIER();
   NoBarrier_Store(ptr, value);
@@ -361,11 +328,6 @@ inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
   Atomic64 value = NoBarrier_Load(ptr);
   ATOMICOPS_COMPILER_BARRIER();
   return value;
-}
-
-inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
-  MemoryBarrier();
-  return NoBarrier_Load(ptr);
 }
 
 #endif // defined(__x86_64__)

--- a/src/base/atomicops.h
+++ b/src/base/atomicops.h
@@ -205,11 +205,6 @@ inline void NoBarrier_Store(volatile AtomicWord *ptr, AtomicWord value) {
       reinterpret_cast<volatile AtomicWordCastType*>(ptr), value);
 }
 
-inline void Acquire_Store(volatile AtomicWord* ptr, AtomicWord value) {
-  return base::subtle::Acquire_Store(
-      reinterpret_cast<volatile AtomicWordCastType*>(ptr), value);
-}
-
 inline void Release_Store(volatile AtomicWord* ptr, AtomicWord value) {
   return base::subtle::Release_Store(
       reinterpret_cast<volatile AtomicWordCastType*>(ptr), value);
@@ -222,11 +217,6 @@ inline AtomicWord NoBarrier_Load(volatile const AtomicWord *ptr) {
 
 inline AtomicWord Acquire_Load(volatile const AtomicWord* ptr) {
   return base::subtle::Acquire_Load(
-      reinterpret_cast<volatile const AtomicWordCastType*>(ptr));
-}
-
-inline AtomicWord Release_Load(volatile const AtomicWord* ptr) {
-  return base::subtle::Release_Load(
       reinterpret_cast<volatile const AtomicWordCastType*>(ptr));
 }
 
@@ -268,11 +258,9 @@ Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
                                 Atomic32 old_value,
                                 Atomic32 new_value);
 void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value);
-void Acquire_Store(volatile Atomic32* ptr, Atomic32 value);
 void Release_Store(volatile Atomic32* ptr, Atomic32 value);
 Atomic32 NoBarrier_Load(volatile const Atomic32* ptr);
 Atomic32 Acquire_Load(volatile const Atomic32* ptr);
-Atomic32 Release_Load(volatile const Atomic32* ptr);
 
 // Corresponding operations on Atomic64
 Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
@@ -289,11 +277,9 @@ Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
                                 Atomic64 old_value,
                                 Atomic64 new_value);
 void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value);
-void Acquire_Store(volatile Atomic64* ptr, Atomic64 value);
 void Release_Store(volatile Atomic64* ptr, Atomic64 value);
 Atomic64 NoBarrier_Load(volatile const Atomic64* ptr);
 Atomic64 Acquire_Load(volatile const Atomic64* ptr);
-Atomic64 Release_Load(volatile const Atomic64* ptr);
 }  // namespace base::subtle
 }  // namespace base
 
@@ -321,20 +307,12 @@ inline AtomicWord Release_CompareAndSwap(volatile AtomicWord* ptr,
   return base::subtle::Release_CompareAndSwap(ptr, old_value, new_value);
 }
 
-inline void Acquire_Store(volatile AtomicWord* ptr, AtomicWord value) {
-  return base::subtle::Acquire_Store(ptr, value);
-}
-
 inline void Release_Store(volatile AtomicWord* ptr, AtomicWord value) {
   return base::subtle::Release_Store(ptr, value);
 }
 
 inline AtomicWord Acquire_Load(volatile const AtomicWord* ptr) {
   return base::subtle::Acquire_Load(ptr);
-}
-
-inline AtomicWord Release_Load(volatile const AtomicWord* ptr) {
-  return base::subtle::Release_Load(ptr);
 }
 #endif  // AtomicWordCastType
 
@@ -350,17 +328,11 @@ inline Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
                                        Atomic32 new_value) {
   return base::subtle::Release_CompareAndSwap(ptr, old_value, new_value);
 }
-inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
-  base::subtle::Acquire_Store(ptr, value);
-}
 inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
   return base::subtle::Release_Store(ptr, value);
 }
 inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
   return base::subtle::Acquire_Load(ptr);
-}
-inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
-  return base::subtle::Release_Load(ptr);
 }
 
 #ifdef BASE_HAS_ATOMIC64
@@ -377,10 +349,6 @@ inline base::subtle::Atomic64 Release_CompareAndSwap(
     base::subtle::Atomic64 old_value, base::subtle::Atomic64 new_value) {
   return base::subtle::Release_CompareAndSwap(ptr, old_value, new_value);
 }
-inline void Acquire_Store(
-    volatile base::subtle::Atomic64* ptr, base::subtle::Atomic64 value) {
-  base::subtle::Acquire_Store(ptr, value);
-}
 inline void Release_Store(
     volatile base::subtle::Atomic64* ptr, base::subtle::Atomic64 value) {
   return base::subtle::Release_Store(ptr, value);
@@ -388,10 +356,6 @@ inline void Release_Store(
 inline base::subtle::Atomic64 Acquire_Load(
     volatile const base::subtle::Atomic64* ptr) {
   return base::subtle::Acquire_Load(ptr);
-}
-inline base::subtle::Atomic64 Release_Load(
-    volatile const base::subtle::Atomic64* ptr) {
-  return base::subtle::Release_Load(ptr);
 }
 
 #endif  // BASE_HAS_ATOMIC64

--- a/src/tests/atomicops_unittest.cc
+++ b/src/tests/atomicops_unittest.cc
@@ -104,11 +104,6 @@ static void TestStore() {
   base::subtle::NoBarrier_Store(&value, kVal2);
   ASSERT_EQ(kVal2, value);
 
-  base::subtle::Acquire_Store(&value, kVal1);
-  ASSERT_EQ(kVal1, value);
-  base::subtle::Acquire_Store(&value, kVal2);
-  ASSERT_EQ(kVal2, value);
-
   base::subtle::Release_Store(&value, kVal1);
   ASSERT_EQ(kVal1, value);
   base::subtle::Release_Store(&value, kVal2);
@@ -133,11 +128,6 @@ static void TestLoad() {
   ASSERT_EQ(kVal1, base::subtle::Acquire_Load(&value));
   value = kVal2;
   ASSERT_EQ(kVal2, base::subtle::Acquire_Load(&value));
-
-  value = kVal1;
-  ASSERT_EQ(kVal1, base::subtle::Release_Load(&value));
-  value = kVal2;
-  ASSERT_EQ(kVal2, base::subtle::Release_Load(&value));
 }
 
 template <class AtomicType>


### PR DESCRIPTION
gperftools' internal atomicops library included atomic
Release Load and Acquire Store operations; those operations
were unused and expressed ordering constraints that aren't
expressible in the C++ standard memory model.

Remove them, to make a transition to C++11 atomics easier
and to avoid confusing use of them.