### PR TITLE
profile-handler: prefer documented sigev_notify_thread_id in sigevent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ check_include_file("sys/cdefs.h" HAVE_SYS_CDEFS_H) # Where glibc defines __THROW
 
 check_include_file("unistd.h" HAVE_UNISTD_H)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_include_file("linux/signal.h" HAVE_LINUX_SIGNAL_H)
 # We also need <ucontext.h>/<sys/ucontext.h>, but we get those from
 # AC_PC_FROM_UCONTEXT, below.
 

--- a/configure.ac
+++ b/configure.ac
@@ -203,7 +203,7 @@ AC_CHECK_FUNCS(sbrk)            # for tcmalloc to get memory
 AC_CHECK_FUNCS(__sbrk)          # for tcmalloc to get memory
 AC_CHECK_FUNCS(geteuid)         # for turning off services when run as root
 AC_CHECK_FUNCS(fork)            # for the pthread_atfork setup
-AC_CHECK_HEADERS(features.h)    # for vdso_support.h
+AC_CHECK_HEADERS(features.h)    # for vdso_support.h, __GLIBC__ macros
 AC_CHECK_HEADERS(malloc.h)      # some systems define stuff there, others not
 AC_CHECK_HEADERS(glob.h)        # for heap-profile-table (cleaning up profiles)
 AC_CHECK_HEADERS(execinfo.h)    # for stacktrace? and heapchecker_unittest
@@ -222,7 +222,6 @@ AC_CHECK_HEADERS(pwd.h)         # for heapchecker_unittest
 AC_CHECK_HEADERS(sys/resource.h)         # for memalign_unittest.cc
 AC_CHECK_HEADERS(valgrind.h)    # we have a local copy if this isn't found
 AC_CHECK_HEADERS(sys/cdefs.h)   # Where glibc defines __THROW
-AC_CHECK_HEADERS(features.h)    # Where __GLIBC__ is defined
 # We also need <ucontext.h>/<sys/ucontext.h>, but we get those from
 # AC_PC_FROM_UCONTEXT, below.
 

--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,7 @@ AC_CHECK_HEADERS(pwd.h)         # for heapchecker_unittest
 AC_CHECK_HEADERS(sys/resource.h)         # for memalign_unittest.cc
 AC_CHECK_HEADERS(valgrind.h)    # we have a local copy if this isn't found
 AC_CHECK_HEADERS(sys/cdefs.h)   # Where glibc defines __THROW
+AC_CHECK_HEADERS(linux/signal.h) # for sigev_notify_thread_id on glibc system
 # We also need <ucontext.h>/<sys/ucontext.h>, but we get those from
 # AC_PC_FROM_UCONTEXT, below.
 

--- a/src/profile-handler.cc
+++ b/src/profile-handler.cc
@@ -49,6 +49,11 @@
 #if HAVE_LINUX_SIGEV_THREAD_ID
 // for timer_{create,settime} and associated typedefs & constants
 #include <time.h>
+
+#ifdef HAVE_LINUX_SIGNAL_H
+#include <linux/signal.h>
+#endif
+
 // for sys_gettid
 #include "base/linux_syscall_support.h"
 // for perftools_pthread_key_create
@@ -272,7 +277,7 @@ static void StartLinuxThreadTimer(int timer_type, int signal_number,
   struct itimerspec its;
   memset(&sevp, 0, sizeof(sevp));
   sevp.sigev_notify = SIGEV_THREAD_ID;
-  sevp._sigev_un._tid = sys_gettid();
+  sevp.sigev_notify_thread_id = sys_gettid();
   sevp.sigev_signo = signal_number;
   clockid_t clock = CLOCK_THREAD_CPUTIME_ID;
   if (timer_type == ITIMER_REAL) {


### PR DESCRIPTION
sigevent(7) is documented to have sigev_notify_thread_id as its member.
In glibc system, it's a macro expanded to the legacy _sigev_un._tid,
_sigev_un._tid is obviously an internal implementation detail as
signaled by its underscore prefix.

On Linux that use musl libc, sigev_notify_thread_id is also a macro, but
it's expanded to __sev_fields.sigev_notify_thread_id

Let's use the documented member if exists with a fallback to the
undocumented member instead.

