### PR TITLE
tcmalloc: Switch thread-safety annotations to support clang

### DIFF
--- a/src/base/low_level_alloc.cc
+++ b/src/base/low_level_alloc.cc
@@ -248,7 +248,7 @@ namespace {
       this->arena_->mu.Lock();
     }
     ~ArenaLock() { RAW_CHECK(this->left_, "haven't left Arena region"); }
-    void Leave() /*UNLOCK_FUNCTION()*/ {
+    void Leave() UNLOCK_FUNCTION() {
       this->arena_->mu.Unlock();
 #if 0
       if (this->mask_valid_) {

--- a/src/base/spinlock.h
+++ b/src/base/spinlock.h
@@ -63,9 +63,7 @@ class LOCKABLE SpinLock {
   }
 
   // Acquire this SpinLock.
-  // TODO(csilvers): uncomment the annotation when we figure out how to
-  //                 support this macro with 0 args (see thread_annotations.h)
-  inline void Lock() /*EXCLUSIVE_LOCK_FUNCTION()*/ {
+  inline void Lock() EXCLUSIVE_LOCK_FUNCTION() {
     if (base::subtle::Acquire_CompareAndSwap(&lockword_, kSpinLockFree,
                                              kSpinLockHeld) != kSpinLockFree) {
       SlowLock();
@@ -84,9 +82,7 @@ class LOCKABLE SpinLock {
   }
 
   // Release this SpinLock, which must be held by the calling thread.
-  // TODO(csilvers): uncomment the annotation when we figure out how to
-  //                 support this macro with 0 args (see thread_annotations.h)
-  inline void Unlock() /*UNLOCK_FUNCTION()*/ {
+  inline void Unlock() UNLOCK_FUNCTION() {
     uint64 prev_value = static_cast<uint64>(
         base::subtle::Release_AtomicExchange(&lockword_, kSpinLockFree));
     if (prev_value != kSpinLockHeld) {
@@ -127,9 +123,7 @@ class SCOPED_LOCKABLE SpinLockHolder {
       : lock_(l) {
     l->Lock();
   }
-  // TODO(csilvers): uncomment the annotation when we figure out how to
-  //                 support this macro with 0 args (see thread_annotations.h)
-  inline ~SpinLockHolder() /*UNLOCK_FUNCTION()*/ { lock_->Unlock(); }
+  inline ~SpinLockHolder() UNLOCK_FUNCTION() { lock_->Unlock(); }
 };
 // Catch bug where variable name is omitted, e.g. SpinLockHolder (&lock);
 #define SpinLockHolder(x) COMPILE_ASSERT(0, spin_lock_decl_missing_var_name)

--- a/src/base/thread_annotations.h
+++ b/src/base/thread_annotations.h
@@ -36,8 +36,8 @@
 // of their multi-threaded code. The annotations can also help program
 // analysis tools to identify potential thread safety issues.
 //
-// The annotations are implemented using GCC's "attributes" extension.
-// Using the macros defined here instead of the raw GCC attributes allows
+// The annotations are implemented using clang's "attributes" extension.
+// Using the macros defined here instead of the raw clang attributes allows
 // for portability and future compatibility.
 //
 // This functionality is not yet fully implemented in perftools,
@@ -47,9 +47,7 @@
 #define BASE_THREAD_ANNOTATIONS_H_
 
 
-#if defined(__GNUC__) \
-  && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)) \
-  && defined(__SUPPORT_TS_ANNOTATION__) && (!defined(SWIG))
+#if defined(__clang__)
 #define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
 #else
 #define THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
@@ -114,19 +112,19 @@
 
 // The following annotations specify lock and unlock primitives.
 #define EXCLUSIVE_LOCK_FUNCTION(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock(x))
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock_function(x))
 
 #define SHARED_LOCK_FUNCTION(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(shared_lock(x))
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_lock_function(x))
 
 #define EXCLUSIVE_TRYLOCK_FUNCTION(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock(x))
+  THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock_function(x))
 
 #define SHARED_TRYLOCK_FUNCTION(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock(x))
+  THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock_function(x))
 
 #define UNLOCK_FUNCTION(x) \
-  THREAD_ANNOTATION_ATTRIBUTE__(unlock(x))
+  THREAD_ANNOTATION_ATTRIBUTE__(unlock_function(x))
 
 // An escape hatch for thread safety analysis to ignore the annotated function.
 #define NO_THREAD_SAFETY_ANALYSIS \

--- a/src/central_freelist.h
+++ b/src/central_freelist.h
@@ -82,11 +82,11 @@ class CentralFreeList {
 
   // Lock/Unlock the internal SpinLock. Used on the pthread_atfork call
   // to set the lock in a consistent state before the fork.
-  void Lock() {
+  void Lock() EXCLUSIVE_LOCK_FUNCTION(lock_) {
     lock_.Lock();
   }
 
-  void Unlock() {
+  void Unlock() UNLOCK_FUNCTION(lock_) {
     lock_.Unlock();
   }
 

--- a/src/static_vars.cc
+++ b/src/static_vars.cc
@@ -52,14 +52,14 @@ namespace tcmalloc {
 // sure the central_cache locks remain in a consisten state in the forked
 // version of the thread.
 
-void CentralCacheLockAll()
+void CentralCacheLockAll() NO_THREAD_SAFETY_ANALYSIS
 {
   Static::pageheap_lock()->Lock();
   for (int i = 0; i < Static::num_size_classes(); ++i)
     Static::central_cache()[i].Lock();
 }
 
-void CentralCacheUnlockAll()
+void CentralCacheUnlockAll() NO_THREAD_SAFETY_ANALYSIS
 {
   for (int i = 0; i < Static::num_size_classes(); ++i)
     Static::central_cache()[i].Unlock();


### PR DESCRIPTION
tcmalloc contains its own copy of thread_annotations.h, wrapper
macros for static thread-safety analysis expressions. These thread-
safety expressions allow asserting (at compile time) that certain
locks are held or excluded or certain data is protected by specific
locks; they are checked at compile-time by recent versions of clang
or a gcc branch (https://gcc.gnu.org/wiki/ThreadSafetyAnnotation).

Convert the #if-guard and macro names from the no-longer-supported
gcc branch's defines & macros to the versions supported by recent
versions of clang.