### PR TITLE
README: replace "golang" moniker with "Go"

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ https://groups.google.com/forum/#!forum/gperftools
 
 gperftools was original home for pprof program. But do note that
 original pprof (which is still included with gperftools) is now
-deprecated in favor of golang version at https://github.com/google/pprof
+deprecated in favor of Go version at https://github.com/google/pprof
 
 
 TCMALLOC


### PR DESCRIPTION
This commit replaces the "golang" moniker in the README file with the
appropriate name of "Go" per https://golang.org/doc/faq#go_or_golang.

In this context, no disambiguation is required.