### PR TITLE
Add an arm64 implementation for SpinlockPause()

### DIFF
--- a/src/base/spinlock.cc
+++ b/src/base/spinlock.cc
@@ -67,6 +67,8 @@ static SpinLock_InitHelper init_helper;
 inline void SpinlockPause(void) {
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
   __asm__ __volatile__("rep; nop" : : );
+#elif defined(__GNUC__) && defined(__aarch64__)
+  __asm__ __volatile__("isb" : : );
 #endif
 }
 


### PR DESCRIPTION
This patch adds an arm64 implementation of the SpinlockPause() function
allowing the core to adaptively spin to acquire the lock and improving
performance in multi-threaded environments where the locks can be contended.

From experience with other projects, we've found a single isb is the closest
corollary to the rep; nop timing or x86.

Overall, across thirty runs, the binary_trees_shared benchmark improves 6% in
average, median, and P90 runtime with this change.