### PR TITLE
free memory with mmap(PROT_NONE, MAP_FIXED)

### DIFF
--- a/src/system-alloc.cc
+++ b/src/system-alloc.cc
@@ -511,7 +511,7 @@ void* TCMalloc_SystemAlloc(size_t size, size_t *actual_size,
 }
 
 bool TCMalloc_SystemRelease(void* start, size_t length) {
-#ifdef MADV_FREE
+#if defined(MADV_FREE) || defined(FREE_MMAP_PROT_NONE) && defined(HAVE_MMAP)
   if (FLAGS_malloc_devmem_start) {
     // It's not safe to use MADV_FREE/MADV_DONTNEED if we've been
     // mapping /dev/mem for heap memory.
@@ -535,6 +535,15 @@ bool TCMalloc_SystemRelease(void* start, size_t length) {
   ASSERT(new_start >= reinterpret_cast<size_t>(start));
   ASSERT(new_end <= end);
 
+#if defined(FREE_MMAP_PROT_NONE) && defined(HAVE_MMAP)
+  // mmap PROT_NONE is similar to munmap by freeing backing pages by physical 
+  // memory except using MAP_FIXED keeps virtual memory range reserved to be
+  // remapped back later
+  return MAP_FAILED != mmap(reinterpret_cast<char*>(new_start),
+                            new_end - new_start,
+                            PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED,
+                            -1, 0);
+#elif defined (MADV_FREE)
   if (new_end > new_start) {
     int result;
     do {
@@ -545,11 +554,19 @@ bool TCMalloc_SystemRelease(void* start, size_t length) {
     return result != -1;
   }
 #endif
+#endif 
   return false;
 }
 
 void TCMalloc_SystemCommit(void* start, size_t length) {
+#if defined(FREE_MMAP_PROT_NONE) && defined(HAVE_MMAP)
+  // remaping as MAP_FIXED to same address assuming span size did not change 
+  // since last TCMalloc_SystemRelease
+  mmap(start, length, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED,
+       -1, 0);
+#elif defined(MADV_FREE)
   // Nothing to do here.  TCMalloc_SystemRelease does not alter pages
   // such that they need to be re-committed before they can be used by the
   // application.
+#endif
 }


### PR DESCRIPTION
For some platforms that madvise(ptr, size, MADV_FREE) has no effect here is alternative solution provided with mmap(PROT_NONE, MAP_FIXED) to keep pages mapped but not backed up by physical memory pages. That counts as free by some systems/tools, tested on QNX with platform available tools.