### PR TITLE
check Span* before Next & ReleaseToSpans

### DIFF
--- a/src/central_freelist.h
+++ b/src/central_freelist.h
@@ -130,7 +130,7 @@ class CentralFreeList {
   // REQUIRES: lock_ is held
   // Release an object to spans.
   // May temporarily release lock_.
-  void ReleaseToSpans(void* object) EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  void ReleaseToSpans(void* object, Span* span) EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   // REQUIRES: lock_ is held
   // Populate cache by fetching from the page heap.

--- a/src/internal_logging.h
+++ b/src/internal_logging.h
@@ -118,8 +118,10 @@ do {                                                                     \
 // all kinds of goofy printing while holding the malloc lock.
 #ifndef NDEBUG
 #define ASSERT(cond) CHECK_CONDITION(cond)
+#define LOG_LEVEL_EXPECT ::tcmalloc::kCrash
 #else
 #define ASSERT(cond) ((void) 0)
+#define LOG_LEVEL_EXPECT ::tcmalloc::kLog
 #endif
 
 // Print into buffer


### PR DESCRIPTION

added Span* check  at `void CentralFreeList::ReleaseListToSpans(void* start)` before calling/using the start-pointer.
changed `void CentralFreeList::ReleaseToSpans` added Span* argument `(void* object, Span* span)`
added Macro `LOG_LEVEL_EXPECT` at Debug "Crash" (as ASSERT) rest only "Log" information.

The difference in the result, In a non-debug build instead of a segmentation on nullptr access, the Bad Span will be logged and break the release loop. A debug build (as use to be) will abort with additional Bad Span information.
- In production run-time (instead the Segmentation at nullptr), There is the need, at Log-Info found, of an app restart and report the logs cases of `Bad Span`/`Bad List` .

Fixes: #1302 