### PR TITLE
Detect Valgrind based on LD_PRELOAD patterns.

### DIFF
--- a/src/base/dynamic_annotations.c
+++ b/src/base/dynamic_annotations.c
@@ -43,6 +43,19 @@
 #include "base/dynamic_annotations.h"
 #include "getenv_safe.h" // for TCMallocGetenvSafe
 
+static int running_on_valgrind_preload = -1;
+void __attribute__ ((constructor)) premain() {
+  char *LD_PRELOAD = getenv("LD_PRELOAD");
+  running_on_valgrind_preload = LD_PRELOAD != NULL &&
+    (
+      strstr(LD_PRELOAD, "/valgrind/") != NULL
+      ||
+      strstr(LD_PRELOAD, "/vgpreload") != NULL
+    )
+    ?
+    1 : 0;
+}
+
 static int GetRunningOnValgrind(void) {
 #ifdef RUNNING_ON_VALGRIND
   if (RUNNING_ON_VALGRIND) return 1;
@@ -51,6 +64,11 @@ static int GetRunningOnValgrind(void) {
   if (running_on_valgrind_str) {
     return strcmp(running_on_valgrind_str, "0") != 0;
   }
+
+  // use the LD_PRELOAD trick from https://stackoverflow.com/questions/365458/how-can-i-detect-if-a-program-is-running-from-within-valgrind
+  if (running_on_valgrind_preload == 1)
+    return 1;
+
   return 0;
 }
 


### PR DESCRIPTION
This patch adds a more reliable way to detect that the process is run under Valgrind.

It is based on this suggestion: https://stackoverflow.com/questions/365458/how-can-i-detect-if-a-program-is-running-from-within-valgrind
