### PR TITLE
 regardless of system capabilities and continue to release span

### DIFF
--- a/src/page_heap.cc
+++ b/src/page_heap.cc
@@ -510,8 +510,6 @@ Length PageHeap::ReleaseAtLeastNPages(Length num_pages) {
       // large freelist, should we carve s instead of releasing?
       // the whole thing?
       Length released_len = ReleaseSpan(s);
-      // Some systems do not support release
-      if (released_len == 0) return released_pages;
       released_pages += released_len;
     }
   }


### PR DESCRIPTION
There have so much more situations which will release span failed. such as: when default_tcmalloc_pagesize is smaller than kernel pagesize(https://github.com/gperftools/gperftools/pull/1269) , and this will lead to failure to recycle resource in time, and cause memory growth(https://github.com/gperftools/gperftools/pull/1201). 
So delete this line.