### PR TITLE
Add support for LoongArch.

### DIFF
--- a/m4/pc_from_ucontext.m4
+++ b/m4/pc_from_ucontext.m4
@@ -26,6 +26,7 @@ AC_DEFUN([AC_PC_FROM_UCONTEXT],
    pc_fields="$pc_fields uc_mcontext.gregs[[REG_EIP]]" # Linux (i386)
    pc_fields="$pc_fields uc_mcontext.gregs[[REG_RIP]]" # Linux (x86_64)
    pc_fields="$pc_fields uc_mcontext.sc_ip"            # Linux (ia64)
+   pc_fields="$pc_fields uc_mcontext.__pc"               # Linux (loongarch64)
    pc_fields="$pc_fields uc_mcontext.pc"               # Linux (mips)
    pc_fields="$pc_fields uc_mcontext.uc_regs->gregs[[PT_NIP]]" # Linux (ppc)
    pc_fields="$pc_fields uc_mcontext.__gregs[[REG_PC]]"  # Linux (riscv64)

--- a/src/base/basictypes.h
+++ b/src/base/basictypes.h
@@ -387,6 +387,8 @@ class AssignAttributeStartEnd {
 #   define CACHELINE_ALIGNED __attribute__((aligned(64)))
 # elif (defined(__e2k__))
 #   define CACHELINE_ALIGNED __attribute__((aligned(64)))
+# elif defined(__loongarch64)
+#   define CACHELINE_ALIGNED __attribute__((aligned(64)))
 # else
 #   error Could not determine cache line length - unknown architecture
 # endif

--- a/src/base/linuxthreads.h
+++ b/src/base/linuxthreads.h
@@ -42,7 +42,7 @@
  * related platforms should not be difficult.
  */
 #if (defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
-     defined(__mips__) || defined(__PPC__) || defined(__aarch64__) ||       \
+     defined(__mips__) || defined(__PPC__) || defined(__aarch64__) || defined(__loongarch64) || \
      defined(__s390__)) && defined(__linux)
 
 /* Define the THREADS symbol to make sure that there is exactly one core dumper

--- a/src/malloc_hook_mmap_linux.h
+++ b/src/malloc_hook_mmap_linux.h
@@ -54,6 +54,7 @@
 #if defined(__x86_64__) \
     || defined(__PPC64__) \
     || defined(__aarch64__) \
+    || defined(__loongarch64) \
     || (defined(_MIPS_SIM) && (_MIPS_SIM == _ABI64 || _MIPS_SIM == _ABIN32)) \
     || defined(__s390__) || (defined(__riscv) && __riscv_xlen == 64) \
     || defined(__e2k__)

--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -219,7 +219,7 @@ static GetStackImplementation *all_impls[] = {
 
 // ppc and i386 implementations prefer arch-specific asm implementations.
 // arm's asm implementation is broken
-#if defined(__i386__) || defined(__ppc__) || defined(__PPC__)
+#if defined(__i386__) || defined(__ppc__) || defined(__PPC__) || defined(__loongarch64)
 #if !defined(NO_FRAME_POINTER)
 #define TCMALLOC_DONT_PREFER_LIBUNWIND
 #endif

--- a/src/tcmalloc.cc
+++ b/src/tcmalloc.cc
@@ -178,7 +178,7 @@ DECLARE_int64(tcmalloc_heap_limit_mb);
 // jump. I am not able to reproduce that anymore.
 #if !defined(__i386__) && !defined(__x86_64__) && \
     !defined(__ppc__) && !defined(__PPC__) && \
-    !defined(__aarch64__) && !defined(__mips__) && !defined(__arm__)
+    !defined(__aarch64__) && !defined(__mips__) && !defined(__arm__) && !defined(__loongarch64)
 #undef TCMALLOC_NO_ALIASES
 #define TCMALLOC_NO_ALIASES
 #endif


### PR DESCRIPTION
Add support for new loongarch architecture.

Only 64-bit is supported at the moment.

The commit were tested on Loongson-3A5000 processor ,the kernel information is as follows：

```
# uname -a
Linux clfs 5.16.0-rc4 #1 SMP PREEMPT Wed Dec 8 09:07:12 UTC 2021 loongarch64 GNU/Linux
```
The test results is as follows:
```
# ./autogen.sh && ./configure && make -j`getconf _NPROCESSORS_ONLN` && make check
....
============================================================================
Testsuite summary for gperftools 2.9.1
============================================================================
# TOTAL: 49
# PASS:  49
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
....
```
