### PR TITLE
avoid linux uapi headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ check_include_file("execinfo.h" HAVE_EXECINFO_H) # for stacktrace? and heapcheck
 check_include_file("unwind.h" HAVE_UNWIND_H) # for stacktrace
 check_include_file("sched.h" HAVE_SCHED_H) # for being nice in our spinlock code
 check_include_file("sys/prctl.h" HAVE_SYS_PRCTL_H) # for thread_lister (needed by leak-checker)
-check_include_file("linux/ptrace.h" HAVE_LINUX_PTRACE_H) # also needed by leak-checker
+check_include_file("sys/ptrace.h" HAVE_LINUX_PTRACE_H) # also needed by leak-checker
 check_include_file("sys/syscall.h" HAVE_SYS_SYSCALL_H)
 check_include_file("sys/socket.h" HAVE_SYS_SOCKET_H) # optional; for forking out to symbolizer
 check_include_file("sys/wait.h" HAVE_SYS_WAIT_H) # optional; for forking out to symbolizer

--- a/configure.ac
+++ b/configure.ac
@@ -214,7 +214,7 @@ AC_CHECK_HEADERS(unwind.h)      # for stacktrace
 AC_CHECK_HEADERS(sched.h)       # for being nice in our spinlock code
 AC_CHECK_HEADERS(conflict-signal.h)      # defined on some windows platforms?
 AC_CHECK_HEADERS(sys/prctl.h)   # for thread_lister (needed by leak-checker)
-AC_CHECK_HEADERS(linux/ptrace.h)# also needed by leak-checker
+AC_CHECK_HEADERS(sys/ptrace.h)  # also needed by leak-checker
 AC_CHECK_HEADERS(sys/syscall.h)
 AC_CHECK_HEADERS(sys/socket.h)  # optional; for forking out to symbolizer
 AC_CHECK_HEADERS(sys/wait.h)    # optional; for forking out to symbolizer

--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -160,7 +160,6 @@ extern "C" {
 #include <sys/types.h>
 #include <syscall.h>
 #include <unistd.h>
-#include <linux/unistd.h>
 #include <endian.h>
 #include <fcntl.h>
 

--- a/src/heap-checker.cc
+++ b/src/heap-checker.cc
@@ -53,8 +53,8 @@
 #include <time.h>
 #include <assert.h>
 
-#if defined(HAVE_LINUX_PTRACE_H)
-#include <linux/ptrace.h>
+#ifdef HAVE_SYS_PTRACE_H
+#include <sys/ptrace.h>
 #endif
 #ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
@@ -1010,7 +1010,7 @@ static enum {
 // and in other ways).
 //
 
-#if defined(HAVE_LINUX_PTRACE_H) && defined(HAVE_SYS_SYSCALL_H) && defined(DUMPER)
+#if defined(HAVE_SYS_PTRACE_H) && defined(HAVE_SYS_SYSCALL_H) && defined(DUMPER)
 # if (defined(__i386__) || defined(__x86_64))
 #  define THREAD_REGS i386_regs
 # elif defined(__PPC__)


### PR DESCRIPTION
this avoids needing to install linux-headers to build gperftools.