### PR TITLE
fix compile failed while setting --disable-cpu-profiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,16 +261,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]], [[int32_t v1 = 0; in
                           Define to 1 if int32_t is equivalent to intptr_t)
                 AC_MSG_RESULT([yes])],[AC_MSG_RESULT([no])])
 
-# We want to access the "PC" (Program Counter) register from a struct
-# ucontext.  Every system has its own way of doing that.  We try all the
-# possibilities we know about.  Note REG_PC should come first (REG_RIP
-# is also defined on solaris, but does the wrong thing).  But don't
-# bother if we're not doing cpu-profiling.
-# [*] means that we've not actually tested one of these systems
-if test "$enable_cpu_profiler" = yes; then
-  AC_PC_FROM_UCONTEXT(AC_MSG_WARN(Could not find the PC.  Will not try to compile libprofiler...);
-                      enable_cpu_profiler=no)
-fi
+AC_PC_FROM_UCONTEXT(AC_MSG_WARN(Could not find the PC.  Will not try to compile libprofiler...);
+                    enable_cpu_profiler=no)
 
 # Some tests test the behavior of .so files, and only make sense for dynamic.
 AM_CONDITIONAL(ENABLE_STATIC, test "$enable_static" = yes)


### PR DESCRIPTION
fix a compile error while setting --disable-cpu-profiler
introduced in f4aa2a435eed63fc047448635f705a9c6037bd97

> libtool: compile:  g++ -std=gnu++11 -DHAVE_CONFIG_H -I. -I../gperftools -I./src -I../gperftools/src -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -Wno-unused-result -fno-omit-frame-pointer -g -O2 -MT src/stacktrace.lo -MD -MP -MF src/.deps/stacktrace.Tpo -c ../gperftools/src/stacktrace.cc  -fPIC -DPIC -o src/.libs/stacktrace.o
In file included from ../gperftools/src/stacktrace_impl_setup-inl.h:70:0,
                 from ../gperftools/src/stacktrace.cc:128:
../gperftools/src/stacktrace_generic_fp-inl.h: In function 'int GetStackTraceWithContext_generic_fp(void**, int, int, const void*)':
../gperftools/src/stacktrace_generic_fp-inl.h:202:33: error: ISO C++ forbids declaration of 'type name' with no type [-fpermissive]
     auto uc = static_cast<const ucontext_t*>(ucp);
                                 ^
../gperftools/src/stacktrace_generic_fp-inl.h:202:33: error: expected '>' before 'ucontext_t'
../gperftools/src/stacktrace_generic_fp-inl.h:202:33: error: expected '(' before 'ucontext_t'
../gperftools/src/stacktrace_generic_fp-inl.h:202:33: error: 'ucontext_t' was not declared in this scope
../gperftools/src/stacktrace_generic_fp-inl.h:202:44: error: expected primary-expression before '>' token
     auto uc = static_cast<const ucontext_t*>(ucp);
                                            ^
../gperftools/src/stacktrace_generic_fp-inl.h:202:50: error: expected ')' before ';' token
     auto uc = static_cast<const ucontext_t*>(ucp);
                                                  ^