### PR TITLE
support for visual studio 2019 or higher

### DIFF
--- a/src/windows/override_functions.cc
+++ b/src/windows/override_functions.cc
@@ -50,6 +50,12 @@
 # error This file is intended for use when overriding allocators
 #endif
 
+#ifdef _CRT_NOEXCEPT
+#define _TC_CRT_NOEXCEPT _CRT_NOEXCEPT
+#else
+#define _TC_CRT_NOEXCEPT
+#endif // _CRT_NOEXCEPT
+
 #include "tcmalloc.cc"
 
 extern "C" {
@@ -87,11 +93,19 @@ void* _recalloc(void* old_ptr, size_t n, size_t size) {
   return new_ptr;
 }
 
+void* _recalloc_base(void* old_ptr, size_t n, size_t size) {
+  return _recalloc(old_ptr, n, size);
+}
+
 void* _calloc_impl(size_t n, size_t size) {
   return calloc(n, size);
 }
 
 size_t _msize(void* p) {
+  return MallocExtension::instance()->GetAllocatedSize(p);
+}
+
+size_t _msize_base(void* p) _TC_CRT_NOEXCEPT {
   return MallocExtension::instance()->GetAllocatedSize(p);
 }
 


### PR DESCRIPTION
In case of Release-Override(/mt) on vs2019
issue:[1327](https://github.com/gperftools/gperftools/issues/1327)

after using a higher version of the sdk, the compiler will report an error such as the issue (1327), because some functions are not rewritten