### PR TITLE
Remove unused using declaration

### DIFF
--- a/src/heap-profiler.cc
+++ b/src/heap-profiler.cc
@@ -83,7 +83,6 @@
 #endif
 
 using std::string;
-using std::sort;
 
 //----------------------------------------------------------------------
 // Flags that control heap-profiling


### PR DESCRIPTION
std::sort in `heap-profiler.cc` is not in use, so remove it.