### PR TITLE
libc_override_osx.h: a small fix for ppc

### DIFF
--- a/src/libc_override_osx.h
+++ b/src/libc_override_osx.h
@@ -276,9 +276,11 @@ static void ReplaceSystemAlloc() {
     MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
   // Switch to version 6 on OSX 10.6 to support memalign.
   tcmalloc_zone.version = 6;
-  tcmalloc_zone.free_definite_size = &mz_free_definite_size;
   tcmalloc_zone.memalign = &mz_memalign;
+#ifndef __POWERPC__
+  tcmalloc_zone.free_definite_size = &mz_free_definite_size;
   tcmalloc_introspection.zone_locked = &mi_zone_locked;
+#endif
 
   // Request the default purgable zone to force its creation. The
   // current default zone is registered with the purgable zone for


### PR DESCRIPTION
This fix concerns very few people, but hurts no one: `ppc32` is supported on 10.6, both natively (in a few developer builds of 10.6) and in Rosetta. But some things do not work there as on Intel:
```
In file included from src/libc_override.h:84,
                 from src/tcmalloc.cc:150:
src/libc_override_osx.h: In function 'void ReplaceSystemAlloc()':
src/libc_override_osx.h:279:17: error: 'malloc_zone_t' {aka 'struct _malloc_zone_t'} has no member named 'free_definite_size'
  279 |   tcmalloc_zone.free_definite_size = &mz_free_definite_size;
      |                 ^~~~~~~~~~~~~~~~~~
src/libc_override_osx.h:281:26: error: 'malloc_introspection_t' {aka 'struct malloc_introspection_t'} has no member named 'zone_locked'
  281 |   tcmalloc_introspection.zone_locked = &mi_zone_locked;
      |                          ^~~~~~~~~~~
```
With this small patch, build is fixed.