### PR TITLE
Fix compilcation at clang for Android x86_64

### DIFF
--- a/src/base/linux_syscall_support.h
+++ b/src/base/linux_syscall_support.h
@@ -428,7 +428,7 @@ struct kernel_stat {
   uint64_t           st_mtime_nsec_;
   uint64_t           st_ctime_;
   uint64_t           st_ctime_nsec_;
-  int64_t            __unused[3];
+  int64_t            _unused[3];
 };
 #elif defined(__PPC__)
 struct kernel_stat {


### PR DESCRIPTION
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4713.pdf#section.5.10

> In addition, some identifiers are reserved for use by C++ implementations and **shall not be used otherwise**; no
diagnostic is required.
> Each identifier that **contains a double underscore __** or begins with an underscore followed by an uppercase letter **is reserved to the implementation for any use**.

Practically at clang for Android x86_64 causes
```
error: expected member name or ';' after declaration specifiers
  int64_t            __unused[3];
  ~~~~~~~                    ^
```