### PR TITLE
Provide a more performant SpinLockDelay implementation on Windows 8.0 on newer

### DIFF
--- a/src/base/spinlock_win32-inl.h
+++ b/src/base/spinlock_win32-inl.h
@@ -40,6 +40,7 @@ namespace internal {
 
 void SpinLockDelay(std::atomic<int> *w, int32 value, int loop) {
   (void)w;
+  (void)value;
 
 // 0x0602 corresponds to Windows 8.0
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602

--- a/src/base/spinlock_win32-inl.h
+++ b/src/base/spinlock_win32-inl.h
@@ -35,6 +35,15 @@
 
 #include <windows.h>
 
+// 0x0602 corresponds to Windows 8.0
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
+#   define HAVE_WAIT_ON_ADDRESS
+#endif
+
+#ifdef HAVE_WAIT_ON_ADDRESS
+#   pragma comment(lib, "Synchronization.lib")
+#endif
+
 namespace base {
 namespace internal {
 
@@ -42,8 +51,7 @@ void SpinLockDelay(std::atomic<int> *w, int32 value, int loop) {
   (void)w;
   (void)value;
 
-// 0x0602 corresponds to Windows 8.0
-#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
+#ifdef HAVE_WAIT_ON_ADDRESS
   if (loop != 0) {
     auto wait_ns = static_cast<uint64_t>(base::internal::SuggestedDelayNS(loop)) * 16ull;
     auto wait_ms = wait_ns / 1000000ull;
@@ -64,7 +72,7 @@ void SpinLockWake(std::atomic<int> *w, bool all) {
   (void)w;
   (void)all;
 
-#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
+#ifdef HAVE_WAIT_ON_ADDRESS
   if (all) {
     WakeByAddressAll((void*)w);
   } else {


### PR DESCRIPTION
Issue: https://github.com/gperftools/gperftools/issues/1333

This PR provides a more performant SpinLockDelay implementation on Windows 8.0 or newer based on [`WaitOnAddress`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitonaddress) and friends.

`WaitOnAddress` is roughly equivalent to Linux's futex, which is what TCMalloc is currently using on that platform.

There was a previous PR attempt https://github.com/gperftools/gperftools/pull/1350.

This PR addresses a comment to maintain support for Windows 7 or older.
That comment is addressed here by checking `_WIN32_WINNT` during build time.

The TCMalloc user can opt out of this change by using an older version of the Windows SDK or by specifying [`_WIN32_WINNT`](https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170) to an older value.