### PR TITLE
Fixes and improvement to Windows CMake build; Add ability to disable TCMalloc on Windows during startup; Improve spinlock performance on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,6 +567,7 @@ if(MINGW OR MSVC)
   # (We do this via a #pragma for msvc, but need to do it here for mingw).
   target_link_libraries(sysinfo shlwapi)
   # spinlock uses WaitOnAddress et al. We need to link to synchronization.lib
+  # (We also do this via a #pragma for msvc, but need to do it here for mingw).
   target_link_libraries(spinlock synchronization)
 
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -854,6 +854,7 @@ if(BUILD_TESTING)
           src/tests/mmap_hook_test.cc
           src/mmap_hook.cc)
   if(MSVC)
+    # Work around unresolved symbol from src/windows by linking against the entire library
     target_link_libraries(mmap_hook_test tcmalloc_minimal Threads::Threads)
   else()
     target_link_libraries(mmap_hook_test spinlock sysinfo logging)
@@ -892,7 +893,9 @@ if(BUILD_TESTING)
 
   add_executable(page_heap_test src/tests/page_heap_test.cc)
   if(MSVC)
-    # Temporary hack as discussed in commit e521472
+    # page_heap_test was changed such that it now refers to an unexported symbol.
+    # Temporary workaround by linking to the .obj files instead of tcmalloc_minimal.
+    # Also see commit e521472 for the VSProj changes.
     target_link_libraries(page_heap_test PRIVATE tcmalloc_minimal_internal Threads::Threads)
   else()
     target_link_libraries(page_heap_test tcmalloc_minimal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,7 +853,11 @@ if(BUILD_TESTING)
   add_executable(mmap_hook_test
           src/tests/mmap_hook_test.cc
           src/mmap_hook.cc)
-  target_link_libraries(mmap_hook_test spinlock sysinfo logging)
+  if(MSVC)
+    target_link_libraries(mmap_hook_test tcmalloc_minimal Threads::Threads)
+  else()
+    target_link_libraries(mmap_hook_test spinlock sysinfo logging)
+  endif()
   add_test(mmap_hook_test mmap_hook_test)
 
   set(malloc_extension_test_SOURCES src/tests/malloc_extension_test.cc
@@ -888,7 +892,8 @@ if(BUILD_TESTING)
 
   add_executable(page_heap_test src/tests/page_heap_test.cc)
   if(MSVC)
-    target_link_libraries(page_heap_test tcmalloc_minimal_static)
+    # Temporary hack as discussed in commit e521472
+    target_link_libraries(page_heap_test PRIVATE tcmalloc_minimal_internal Threads::Threads)
   else()
     target_link_libraries(page_heap_test tcmalloc_minimal)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,8 @@ if(MINGW OR MSVC)
   # We also need to tell mingw that sysinfo.cc needs shlwapi.lib.
   # (We do this via a #pragma for msvc, but need to do it here for mingw).
   target_link_libraries(sysinfo shlwapi)
+  # spinlock uses WaitOnAddress et al. We need to link to synchronization.lib
+  target_link_libraries(spinlock synchronization)
 
 else()
   set(SPINLOCK_INCLUDES src/base/spinlock.h

--- a/src/base/spinlock_win32-inl.h
+++ b/src/base/spinlock_win32-inl.h
@@ -32,7 +32,9 @@
  * This file is a Win32-specific part of spinlock_internal.cc
  */
 
+
 #include <windows.h>
+#pragma comment(lib, "Synchronization.lib")
 
 namespace base {
 namespace internal {

--- a/src/base/spinlock_win32-inl.h
+++ b/src/base/spinlock_win32-inl.h
@@ -35,19 +35,50 @@
 
 #include <windows.h>
 
+// 0x0602 corresponds to Windows 8.0
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
+#   define HAVE_WAIT_ON_ADDRESS
+#endif
+
+#ifdef HAVE_WAIT_ON_ADDRESS
+#   pragma comment(lib, "Synchronization.lib")
+#endif
+
 namespace base {
 namespace internal {
 
 void SpinLockDelay(std::atomic<int> *w, int32 value, int loop) {
+  (void)w;
+  (void)value;
+
+#ifdef HAVE_WAIT_ON_ADDRESS
+  if (loop != 0) {
+    auto wait_ns = static_cast<uint64_t>(base::internal::SuggestedDelayNS(loop)) * 16;
+    auto wait_ms = wait_ns / 1000000;
+
+    WaitOnAddress(w, &value, 4, static_cast<DWORD>(wait_ms));
+  }
+#else
   if (loop == 0) {
   } else if (loop == 1) {
     Sleep(0);
   } else {
     Sleep(base::internal::SuggestedDelayNS(loop) / 1000000);
   }
+#endif
 }
 
 void SpinLockWake(std::atomic<int> *w, bool all) {
+  (void)w;
+  (void)all;
+
+#ifdef HAVE_WAIT_ON_ADDRESS
+  if (all) {
+    WakeByAddressAll((void*)w);
+  } else {
+    WakeByAddressSingle((void*)w);
+  }
+#endif
 }
 
 } // namespace internal

--- a/src/base/spinlock_win32-inl.h
+++ b/src/base/spinlock_win32-inl.h
@@ -32,53 +32,26 @@
  * This file is a Win32-specific part of spinlock_internal.cc
  */
 
-
 #include <windows.h>
-
-// 0x0602 corresponds to Windows 8.0
-#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0602
-#   define HAVE_WAIT_ON_ADDRESS
-#endif
-
-#ifdef HAVE_WAIT_ON_ADDRESS
-#   pragma comment(lib, "Synchronization.lib")
-#endif
 
 namespace base {
 namespace internal {
 
 void SpinLockDelay(std::atomic<int> *w, int32 value, int loop) {
-  (void)w;
-  (void)value;
-
-#ifdef HAVE_WAIT_ON_ADDRESS
   if (loop != 0) {
     auto wait_ns = static_cast<uint64_t>(base::internal::SuggestedDelayNS(loop)) * 16;
     auto wait_ms = wait_ns / 1000000;
 
     WaitOnAddress(w, &value, 4, static_cast<DWORD>(wait_ms));
   }
-#else
-  if (loop == 0) {
-  } else if (loop == 1) {
-    Sleep(0);
-  } else {
-    Sleep(base::internal::SuggestedDelayNS(loop) / 1000000);
-  }
-#endif
 }
 
 void SpinLockWake(std::atomic<int> *w, bool all) {
-  (void)w;
-  (void)all;
-
-#ifdef HAVE_WAIT_ON_ADDRESS
   if (all) {
     WakeByAddressAll((void*)w);
   } else {
     WakeByAddressSingle((void*)w);
   }
-#endif
 }
 
 } // namespace internal


### PR DESCRIPTION
Merging 3 PRs into one as requested : https://github.com/gperftools/gperftools/pull/1435 https://github.com/gperftools/gperftools/pull/1437 https://github.com/gperftools/gperftools/pull/1438

Issues addressed:
1. https://github.com/gperftools/gperftools/issues/1433 by porting over the VSProj changes https://github.com/gperftools/gperftools/commit/e521472f1ac1ecf028e8c922ca4f8741473afd66
2. [MERGED] Fix https://github.com/gperftools/gperftools/issues/1332
3. [MERGED] https://github.com/gperftools/gperftools/issues/1434
4. [MERGED] https://github.com/gperftools/gperftools/issues/1436
5. Provide a more performant `SpinLockDelay` implementation on Windows or newer to address https://github.com/gperftools/gperftools/issues/1333

Tested with gcc 12.3 on Linux (should be a no-opt) and MSVC 19.31 on Windows.

------------

**More details:**

1. ALL_BUILD can now be completed successfully

2. 
Before:
```
-- Performing Test HAVE_TLS - Failed
```
After;
```
-- Performing Test HAVE_TLS - Success
```

Tested with 
- gcc 12.3 on Linux (Ubuntu 22.04.1 LTS)
- MSVC 19.31 (from EWDK 22621_230511-2102) on Windows 10 22H2.