### PR TITLE
Fix Windows CMake build; Improve spinlock performance on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,9 @@ if(MINGW OR MSVC)
   # We also need to tell mingw that sysinfo.cc needs shlwapi.lib.
   # (We do this via a #pragma for msvc, but need to do it here for mingw).
   target_link_libraries(sysinfo shlwapi)
+  # spinlock uses WaitOnAddress et al. We need to link to synchronization.lib
+  # (We also do this via a #pragma for msvc, but need to do it here for mingw).
+  target_link_libraries(spinlock synchronization)
 
 else()
   set(SPINLOCK_INCLUDES src/base/spinlock.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,7 +853,12 @@ if(BUILD_TESTING)
   add_executable(mmap_hook_test
           src/tests/mmap_hook_test.cc
           src/mmap_hook.cc)
-  target_link_libraries(mmap_hook_test spinlock sysinfo logging)
+  if(MSVC)
+    # Work around unresolved symbol from src/windows by linking against the entire library
+    target_link_libraries(mmap_hook_test tcmalloc_minimal Threads::Threads)
+  else()
+    target_link_libraries(mmap_hook_test spinlock sysinfo logging)
+  endif()
   add_test(mmap_hook_test mmap_hook_test)
 
   set(malloc_extension_test_SOURCES src/tests/malloc_extension_test.cc
@@ -888,7 +893,10 @@ if(BUILD_TESTING)
 
   add_executable(page_heap_test src/tests/page_heap_test.cc)
   if(MSVC)
-    target_link_libraries(page_heap_test tcmalloc_minimal_static)
+    # page_heap_test was changed such that it now refers to an unexported symbol.
+    # Temporary workaround by linking to the .obj files instead of tcmalloc_minimal.
+    # Also see commit e521472 for the VSProj changes.
+    target_link_libraries(page_heap_test PRIVATE tcmalloc_minimal_internal Threads::Threads)
   else()
     target_link_libraries(page_heap_test tcmalloc_minimal)
   endif()

--- a/Makefile.am
+++ b/Makefile.am
@@ -205,6 +205,7 @@ noinst_LTLIBRARIES += libspinlock.la
 libspinlock_la_SOURCES = src/base/spinlock.cc \
                          src/base/spinlock_internal.cc \
                          $(SPINLOCK_INCLUDES)
+libspinlock_la_LIBADD = -lsynchronization
 
 LIBSPINLOCK = libwindows.la libspinlock.la libsysinfo.la liblogging.la
 


### PR DESCRIPTION
Rebased PR from https://github.com/gperftools/gperftools/pull/1439

1. https://github.com/gperftools/gperftools/issues/1433 by porting over the VSProj changes https://github.com/gperftools/gperftools/commit/e521472f1ac1ecf028e8c922ca4f8741473afd66
2. Provide a more performant SpinLockDelay implementation on Windows to address https://github.com/gperftools/gperftools/issues/1333

Tested with gcc 12.3 on Linux and MSVC 19.31 on Windows.