### PR TITLE
Fix C++ aligned allocation detection in the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if(CMAKE_SYSTEM MATCHES Linux)
 endif()
 
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 include(CheckCSourceCompiles)
 include(CheckCXXSourceCompiles)
 include(CheckFunctionExists)
@@ -290,9 +291,12 @@ check_cxx_source_compiles("
   HAVE_STD_ALIGN_VAL_T)
 if(HAVE_STD_ALIGN_VAL_T)
   set(HAVE_STD_ALIGN_VAL_T 1)
+  set(ENABLE_ALIGNED_NEW_DELETE 1)
 else()
   set(HAVE_STD_ALIGN_VAL_T 0)
 endif()
+
+check_cxx_compiler_flag("-faligned-new" have_f_aligned_new)
 
 check_c_source_compiles("
   #include <unwind.h>


### PR DESCRIPTION
There are 2 variables that control TCMalloc support for C++'s aligned allocation functions.
- `HAVE_STD_ALIGN_VAL_T`
- `ENABLE_ALIGNED_NEW_DELETE`

The former is used during configuration time (while generating `gperftools/tcmalloc.h`), while the latter is used during build time.
The CMake build failed to set the second variable.

See configure.ac to see both variables being set in the automake build
https://github.com/gperftools/gperftools/blob/589d416977977f32fde82cd623a7a876ab1d397c/configure.ac#L428
https://github.com/gperftools/gperftools/blob/589d416977977f32fde82cd623a7a876ab1d397c/configure.ac#L433

As a result, both Linux and Windows CMake builds will never generate the `std::align_val_t` symbols.

This PR fixes the inconsistency.

Before:
```
nm -D -C libtcmalloc.so | grep align_
<empty>
```
After:
```
nm -D -C libtcmalloc.so | grep align_
000000000009f133 T operator delete[](void*, std::align_val_t)
000000000009ff79 T operator delete[](void*, std::align_val_t, std::nothrow_t const&)
000000000009f611 T operator delete[](void*, unsigned long, std::align_val_t)
000000000009f133 T operator delete(void*, std::align_val_t)
000000000009ff79 T operator delete(void*, std::align_val_t, std::nothrow_t const&)
000000000009f611 T operator delete(void*, unsigned long, std::align_val_t)
000000000009ed85 T operator new[](unsigned long, std::align_val_t)
000000000009faf6 T operator new[](unsigned long, std::align_val_t, std::nothrow_t const&)
000000000009ed85 T operator new(unsigned long, std::align_val_t)
000000000009faf6 T operator new(unsigned long, std::align_val_t, std::nothrow_t const&)
```