### PR TITLE
Avoid initilizing CheckAddress with a lambda, so that it also works with gcc 6

### DIFF
--- a/src/check_address-inl.h
+++ b/src/check_address-inl.h
@@ -99,10 +99,14 @@ bool CheckAccessTwoSyscalls(uintptr_t addr, int pagesize) {
   return false;
 }
 
+bool CheckAddressFirstCall(uintptr_t addr, int pagesize);
+
+bool (* volatile CheckAddress)(uintptr_t addr, int pagesize) = CheckAddressFirstCall;
+
 // And we choose between strategies by checking at runtime if
 // single-syscall approach actually works and switch to a proper
 // version.
-bool (* volatile CheckAddress)(uintptr_t addr, int pagesize) = [] (uintptr_t addr, int pagesize) {
+bool CheckAddressFirstCall(uintptr_t addr, int pagesize) {
   void* unreadable = mmap(0, pagesize, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
   RAW_CHECK(unreadable != MAP_FAILED, "mmap of unreadable");
 


### PR DESCRIPTION
Hi,

This is an issue we see only with the very latest gperftools 2.13 when using our gcc 6 based toolchains (we have other toolchains using gcc 8, 9, 11 and 13, and it works with all of them except gcc 6).

We have segmentation faults, which are "randomly happening". The stack strace looks like this:

```
#0  0x0000000000000000 in ?? ()
#1  0x00007f927c7832c3 in (anonymous namespace)::stacktrace_generic_fp::CheckPageIsReadable (ptr=0x7ffce1397070, checked_ptr=0x7ffce1396fa0) at src/stacktrace_generic_fp-inl.h:115
#2  0x00007f927c783ff2 in (anonymous namespace)::stacktrace_generic_fp::capture<false, false> (result=0x3705010, max_depth=31, skip_count=1, initial_frame=0x7ffce1396eb0, initial_pc=0x0, sizes=0x0)
    at src/stacktrace_generic_fp-inl.h:179
#3  0x00007f927c783332 in GetStackTrace_generic_fp (result=0x3705010, max_depth=30, skip_count=1) at src/stacktrace_generic_fp-inl.h:338
#4  0x00007f927c783c63 in GetStackTrace (result=0x3705010, max_depth=30, skip_count=0) at src/stacktrace.cc:346
#5  0x00007f927c768a3e in tcmalloc::PageHeap::HandleUnlock (this=0x7f927c7da9c0 <tcmalloc::Static::pageheap_>, context=0x7ffce1396f70) at src/page_heap.cc:155
#6  0x00007f927c76b4cb in tcmalloc::PageHeap::LockingContext::~LockingContext (this=0x7ffce1396f70, __in_chrg=<optimized out>) at src/page_heap.cc:77
#7  0x00007f927c768af8 in tcmalloc::PageHeap::NewWithSizeClass (this=0x7f927c7da9c0 <tcmalloc::Static::pageheap_>, n=9, sizeclass=62) at src/page_heap.cc:161
#8  0x00007f927c76818f in tcmalloc::CentralFreeList::Populate (this=0x7f927c7c6fc0 <tcmalloc::Static::central_cache_+75392>) at src/central_freelist.cc:314
#9  0x00007f927c767fd9 in tcmalloc::CentralFreeList::FetchFromOneSpansSafe (this=0x7f927c7c6fc0 <tcmalloc::Static::central_cache_+75392>, N=1, start=0x7ffce1397158, end=0x7ffce1397150)
    at src/central_freelist.cc:273
#10 0x00007f927c767f15 in tcmalloc::CentralFreeList::RemoveRange (this=0x7f927c7c6fc0 <tcmalloc::Static::central_cache_+75392>, start=0x7ffce1397158, end=0x7ffce1397150, N=1) at src/central_freelist.cc:253
#11 0x00007f927c770209 in tcmalloc::ThreadCache::FetchFromCentralCache (this=0x3725000, cl=62, byte_size=73728, oom_handler=0x7f927c74fe98 <(anonymous namespace)::nop_oom_handler(size_t) at src/tcmalloc.cc:1387>)
    at src/thread_cache.cc:125
#12 0x00007f927c78b05e in tcmalloc::ThreadCache::Allocate (oom_handler=0x7f927c74fe98 <(anonymous namespace)::nop_oom_handler(size_t) at src/tcmalloc.cc:1387>, cl=62, size=73728, this=0x3725000)
    at src/thread_cache.h:381
#13 (anonymous namespace)::do_malloc (size=72704) at src/tcmalloc.cc:1414
#14 tcmalloc::do_allocate_full<tcmalloc::malloc_oom> (size=72704) at src/tcmalloc.cc:1804
#15 tcmalloc::allocate_full_malloc_oom (size=72704) at src/tcmalloc.cc:1820
#16 0x00007f927c786d60 in tcmalloc::dispatch_allocate_full<tcmalloc::malloc_oom> (size=72704) at src/tcmalloc.cc:1833
#17 malloc_fast_path<tcmalloc::malloc_oom> (size=72704) at src/tcmalloc.cc:1881
#18 tc_malloc (size=72704) at src/tcmalloc.cc:1926
#19 0x00007f927ccb3610 in (anonymous namespace)::pool::pool (this=0x7f927cda4be0 <(anonymous namespace)::emergency_pool>) at /workdir/src/gcc-6.5.0/libstdc++-v3/libsupc++/eh_alloc.cc:123
#20 __static_initialization_and_destruction_0 (__priority=65535, __initialize_p=1) at /workdir/src/gcc-6.5.0/libstdc++-v3/libsupc++/eh_alloc.cc:250
```

If I go in frame 1 and `disas`, I can "extract" the address of `CheckAddress`:

```
   0x00007f927c7832a1 <+104>:   mov    $0x1,%eax
   0x00007f927c7832a6 <+109>:   jmp    0x7f927c7832c3 <(anonymous namespace)::stacktrace_generic_fp::CheckPageIsReadable(void*, void*)+138 at src/stacktrace_generic_fp-inl.h:116>
   0x00007f927c7832a8 <+111>:   mov    0x1ddf51(%rip),%rax        # 0x7f927c961200 <(anonymous namespace)::CheckAddress>
   0x00007f927c7832af <+118>:   mov    0x1ddf52(%rip),%rdx        # 0x7f927c961208 <(anonymous namespace)::stacktrace_generic_fp::CheckPageIsReadable(void*, void*)::pagesize>
   0x00007f927c7832b6 <+125>:   mov    %edx,%ecx
   0x00007f927c7832b8 <+127>:   mov    -0x8(%rbp),%rdx
   0x00007f927c7832bc <+131>:   mov    %ecx,%esi
   0x00007f927c7832be <+133>:   mov    %rdx,%rdi
   0x00007f927c7832c1 <+136>:   call   *%rax
=> 0x00007f927c7832c3 <+138>:   leave
   0x00007f927c7832c4 <+139>:   ret
````

and indeed if I try to show what `CheckAddress` points at... it points to nothing really interesting:

```
(gdb) x/a 0x7f927c961200
0x7f927c961200 <(anonymous namespace)::CheckAddress>:   0x0
```

Honestly I am not too sure what is happening, and I didn't really try to investigate why we have 0 here. And I was able to use gdb on similar process which are starting well they have an actual address, showing that they have been called at least once. The segfault happens very early in the startup, in the static constructors of my binary. I assume (without much proof) that relocation and/or static variable initialization didn't happen correctly yet, for some reason. It may be a bug of gcc 6, which I do agree is rather old.

However looking at how `CheckAddress` is defined, it's defined using a lambda. I tried this patch, which I may consider is making the code a little bit more readable (that's a subjective opinion), and then I didn't face any random segmentation faults anymore with gcc 6.

So is it fine for merging ?

Cheers,
Romain