### PR TITLE
Add mallinfo2 function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ check_c_source_compiles("#include <stdlib.h>
 
 set(CMAKE_EXTRA_INCLUDE_FILES "malloc.h")
 check_type_size("struct mallinfo" STRUCT_MALLINFO LANGUAGE CXX)
+check_type_size("struct mallinfo2" STRUCT_MALLINFO2 LANGUAGE CXX)
 set(CMAKE_EXTRA_INCLUDE_FILES "elf.h")
 check_type_size("Elf32_Versym" ELF32_VERSYM LANGUAGE CXX) # for vdso_support.h
 set(CMAKE_EXTRA_INCLUDE_FILES)
@@ -212,6 +213,12 @@ if(HAVE_STRUCT_MALLINFO)
     set(HAVE_STRUCT_MALLINFO 1)
 else()
     set(HAVE_STRUCT_MALLINFO 0)
+endif()
+
+if(HAVE_STRUCT_MALLINFO2)
+    set(HAVE_STRUCT_MALLINFO2 1)
+else()
+    set(HAVE_STRUCT_MALLINFO2 0)
 endif()
 
 # We hardcode HAVE_MMAP to 1. There are no interesting systems anymore

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,7 @@ if HAVE_OBJCOPY_WEAKEN
 WEAKEN = $(OBJCOPY) -W malloc -W free -W realloc -W calloc -W cfree \
          -W memalign -W posix_memalign -W valloc -W pvalloc \
          -W aligned_alloc \
-         -W malloc_stats -W mallopt -W mallinfo -W nallocx \
+         -W malloc_stats -W mallopt -W mallinfo -W mallinfo2 -W nallocx \
          -W _Znwm -W _ZnwmRKSt9nothrow_t -W _Znam -W _ZnamRKSt9nothrow_t \
          -W _ZdlPv -W _ZdaPv \
          -W __Znwm -W __ZnwmRKSt9nothrow_t -W __Znam -W __ZnamRKSt9nothrow_t \

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -128,6 +128,9 @@
 /* Define to 1 if the system has the type `struct mallinfo'. */
 #cmakedefine HAVE_STRUCT_MALLINFO
 
+/* Define to 1 if the system has the type `struct mallinfo2'. */
+#cmakedefine HAVE_STRUCT_MALLINFO2
+
 /* Define to 1 if you have the <sys/cdefs.h> header file. */
 #cmakedefine HAVE_SYS_CDEFS_H
 

--- a/cmake/tcmalloc.h.in
+++ b/cmake/tcmalloc.h.in
@@ -48,7 +48,7 @@
 #define TC_VERSION_STRING "gperftools @PROJECT_VERSION@"
 
 /* For struct mallinfo, if it's defined. */
-#if @HAVE_STRUCT_MALLINFO@
+#if @HAVE_STRUCT_MALLINFO@ || @HAVE_STRUCT_MALLINFO2@
 # include <malloc.h>
 #endif
 
@@ -106,6 +106,9 @@ extern "C" {
   PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW;
 #if @HAVE_STRUCT_MALLINFO@
   PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW;
+#endif
+#if @HAVE_STRUCT_MALLINFO2@
+  PERFTOOLS_DLL_DECL struct mallinfo2 tc_mallinfo2(void) PERFTOOLS_NOTHROW;
 #endif
 
   /*

--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,7 @@ AC_MSG_RESULT($ac_cv___attribute__aligned_fn)
 
 # TODO(csilvers): we could remove a lot when WITH_CPU_PROFILER etc is "no".
 AC_CHECK_TYPES([struct mallinfo],,, [#include <malloc.h>])
+AC_CHECK_TYPES([struct mallinfo2],,, [#include <malloc.h>])
 AC_CHECK_TYPES([Elf32_Versym],,, [#include <elf.h>])   # for vdso_support.h
 AC_CHECK_FUNCS(sbrk)            # for tcmalloc to get memory
 AC_CHECK_FUNCS(__sbrk)          # for tcmalloc to get memory
@@ -295,6 +296,12 @@ if test "$ac_cv_type_struct_mallinfo" = yes; then
   AC_SUBST(ac_cv_have_struct_mallinfo, 1)   # gperftools/tcmalloc.h needs this
 else
   AC_SUBST(ac_cv_have_struct_mallinfo, 0)
+fi
+
+if test "$ac_cv_type_struct_mallinfo2" = yes; then
+  AC_SUBST(ac_cv_have_struct_mallinfo2, 1)   # gperftools/tcmalloc.h needs this
+else
+  AC_SUBST(ac_cv_have_struct_mallinfo2, 0)
 fi
 
 # We hardcode HAVE_MMAP to 1. There are no interesting systems anymore

--- a/src/debugallocation.cc
+++ b/src/debugallocation.cc
@@ -37,8 +37,8 @@
 #include <fcntl.h>
 #endif
 #include <inttypes.h>
-// We only need malloc.h for struct mallinfo.
-#ifdef HAVE_STRUCT_MALLINFO
+// We only need malloc.h for structs mallinfo and mallinfo2.
+#if defined(HAVE_STRUCT_MALLINFO) || defined(HAVE_STRUCT_MALLINFO2)
 // Malloc can be in several places on older versions of OS X.
 # if defined(HAVE_MALLOC_H)
 # include <malloc.h>
@@ -1574,6 +1574,12 @@ extern "C" PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHR
 #ifdef HAVE_STRUCT_MALLINFO
 extern "C" PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW {
   return do_mallinfo();
+}
+#endif
+
+#ifdef HAVE_STRUCT_MALLINFO2
+extern "C" PERFTOOLS_DLL_DECL struct mallinfo2 tc_mallinfo2(void) PERFTOOLS_NOTHROW {
+  return do_mallinfo2();
 }
 #endif
 

--- a/src/gperftools/tcmalloc.h.in
+++ b/src/gperftools/tcmalloc.h.in
@@ -48,7 +48,7 @@
 #define TC_VERSION_STRING "gperftools @TC_VERSION_MAJOR@.@TC_VERSION_MINOR@@TC_VERSION_PATCH@"
 
 /* For struct mallinfo, if it's defined. */
-#if @ac_cv_have_struct_mallinfo@
+#if @ac_cv_have_struct_mallinfo@ || @ac_cv_have_struct_mallinfo2@ 
 # include <malloc.h>
 #endif
 
@@ -106,6 +106,9 @@ extern "C" {
   PERFTOOLS_DLL_DECL int tc_mallopt(int cmd, int value) PERFTOOLS_NOTHROW;
 #if @ac_cv_have_struct_mallinfo@
   PERFTOOLS_DLL_DECL struct mallinfo tc_mallinfo(void) PERFTOOLS_NOTHROW;
+#endif
+#if @ac_cv_have_struct_mallinfo2@
+  PERFTOOLS_DLL_DECL struct mallinfo2 tc_mallinfo2(void) PERFTOOLS_NOTHROW;
 #endif
 
   /*

--- a/src/libc_override_aix.h
+++ b/src/libc_override_aix.h
@@ -51,6 +51,9 @@ extern "C" {
 #ifdef HAVE_STRUCT_MALLINFO
   struct mallinfo __mallinfo__(void) __THROW          ALIAS(tc_mallinfo);
 #endif
+#ifdef HAVE_STRUCT_MALLINFO2
+  struct mallinfo2 __mallinfo2__(void) __THROW        ALIAS(tc_mallinfo2);
+#endif
   void __malloc_init__(void)               { tc_free(tc_malloc(1));}
   void* __malloc_prefork_lock__(void)      { /* nothing to lock */ }
   void* __malloc_postfork_unlock__(void)   { /* nothing to unlock */}

--- a/src/libc_override_gcc_and_weak.h
+++ b/src/libc_override_gcc_and_weak.h
@@ -235,6 +235,9 @@ extern "C" {
 #ifdef HAVE_STRUCT_MALLINFO
   struct mallinfo mallinfo(void) __THROW          ALIAS(tc_mallinfo);
 #endif
+#ifdef HAVE_STRUCT_MALLINFO2
+  struct mallinfo2 mallinfo2(void) __THROW        ALIAS(tc_mallinfo2);
+#endif
   size_t malloc_size(void* p) __THROW             ALIAS(tc_malloc_size);
 #if defined(__ANDROID__)
   size_t malloc_usable_size(const void* p) __THROW

--- a/src/libc_override_redefine.h
+++ b/src/libc_override_redefine.h
@@ -120,6 +120,9 @@ extern "C" {
 #ifdef HAVE_STRUCT_MALLINFO
   struct mallinfo mallinfo(void)                 { return tc_mallinfo();      }
 #endif
+#ifdef HAVE_STRUCT_MALLINFO2
+  struct mallinfo2 mallinfo2(void)               { return tc_mallinfo2();     }
+#endif
   size_t malloc_size(void* p)                    { return tc_malloc_size(p); }
   size_t malloc_usable_size(void* p)             { return tc_malloc_size(p); }
 }  // extern "C"

--- a/src/windows/config.h
+++ b/src/windows/config.h
@@ -145,6 +145,9 @@
 /* Define to 1 if the system has the type `struct mallinfo'. */
 /* #undef HAVE_STRUCT_MALLINFO */
 
+/* Define to 1 if the system has the type `struct mallinfo2'. */
+/* #undef HAVE_STRUCT_MALLINFO2 */
+
 /* Define to 1 if you have the <sys/cdefs.h> header file. */
 /* #undef HAVE_SYS_CDEFS_H */
 


### PR DESCRIPTION
Implemented the function `mallinfo2` that is a fixed version of `mallinfo`.   
The `mallinfo2` is part of glibc since 2.33 and orginal `mallinfo` is now deprecated.

Closes #1414