### PR TITLE
mmap_hook.cc: use MAP_ANON when MAP_ANONYMOUS is not defined

### DIFF
--- a/src/mmap_hook.cc
+++ b/src/mmap_hook.cc
@@ -48,6 +48,9 @@
 #ifdef HAVE_MMAP
 # define mremap glibc_mremap
 # include <sys/mman.h>
+# ifndef MAP_ANONYMOUS
+#  define MAP_ANONYMOUS MAP_ANON
+# endif
 #include <sys/types.h>
 # undef mremap
 #endif


### PR DESCRIPTION
Older macOS (and possibly some other platforms) do not have `MAP_ANONYMOUS`, but have `MAP_ANON`.