### PR TITLE
fix setting page size and page size shift in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,18 +122,31 @@ set(enable_libunwind ${gperftools_enable_libunwind})
 
 set(gperftools_tcmalloc_pagesize ${default_tcmalloc_pagesize}
   CACHE STRING "Set the tcmalloc internal page size")
-set_property(CACHE gperftools_tcmalloc_pagesize PROPERTY STRINGS "8" "32" "64")
-if(NOT gperftools_tcmalloc_pagesize STREQUAL "8" AND
-   NOT gperftools_tcmalloc_pagesize STREQUAL "32" AND
-   NOT gperftools_tcmalloc_pagesize STREQUAL "64")
+set(allowed_page_sizes LIST "4;8;16;32;64;128;256")
+set_property(CACHE gperftools_tcmalloc_pagesize PROPERTY STRINGS ${allowed_page_sizes})
+if(NOT gperftools_tcmalloc_pagesize IN_LIST allowed_page_sizes)
   message(WARNING
     "Invalid gperftools_tcmalloc_pagesize (${gperftools_tcmalloc_pagesize}), "
     "setting to default value (${default_tcmalloc_pagesize})")
   set(gperftools_tcmalloc_pagesize ${default_tcmalloc_pagesize})
 endif()
-if (gperftools_tcmalloc_pagesize STREQUAL "32" OR
-  gperftools_tcmalloc_pagesize STREQUAL "64")
-  set(TCMALLOC_${gperftools_tcmalloc_pagesize}K_PAGES ON)
+if (gperftools_tcmalloc_pagesize EQUAL 4)
+  set(TCMALLOC_PAGE_SIZE_SHIFT 12)
+elseif(gperftools_tcmalloc_pagesize EQUAL 8)
+  # default page size
+elseif(gperftools_tcmalloc_pagesize EQUAL 16)
+  set(TCMALLOC_PAGE_SIZE_SHIFT 14)
+elseif(gperftools_tcmalloc_pagesize EQUAL 32)
+  set(TCMALLOC_PAGE_SIZE_SHIFT 15)
+elseif(gperftools_tcmalloc_pagesize EQUAL 64)
+  set(TCMALLOC_PAGE_SIZE_SHIFT 16)
+elseif(gperftools_tcmalloc_pagesize EQUAL 128)
+  set(TCMALLOC_PAGE_SIZE_SHIFT 17)
+elseif(gperftools_tcmalloc_pagesize EQUAL 256)
+  set(TCMALLOC_PAGE_SIZE_SHIFT 18)
+else()
+  message(WARNING
+  "${gperftools_tcmalloc_pagesize}K size not supported, using default tcmalloc page size.")
 endif()
 
 set(gperftools_tcmalloc_alignment ${DEFAULT_TCMALLOC_ALIGNMENT}

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -240,7 +240,7 @@
 #cmakedefine TCMALLOC_ALIGN_8BYTES
 
 /* Define internal page size for tcmalloc as number of left bitshift */
-#cmakedefine TCMALLOC_PAGE_SIZE_SHIFT
+#cmakedefine TCMALLOC_PAGE_SIZE_SHIFT @TCMALLOC_PAGE_SIZE_SHIFT@
 
 /* Version number of package */
 #define VERSION @PROJECT_VERSION@


### PR DESCRIPTION
Fixed cmake to allow the same page sizes as autotools, and to set `TCMALLOC_PAGE_SIZE_SHIFT` correctly.  
Removed setting `TCMALLOC_${gperftools_tcmalloc_pagesize}K_PAGES` that was never used.

Closes #1373