### PR TITLE
Added missing cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,12 @@ if(LINUX)
     HAVE_LINUX_SIGEV_THREAD_ID)
 endif()
 
+# Disable large allocation report by default.
+option(gperftools_enable_large_alloc_report
+      "Report very large allocations to stderr"
+      OFF)
+set(ENABLE_LARGE_ALLOC_REPORT ${gperftools_enable_large_alloc_report})
+
 configure_file(cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
 configure_file(cmake/tcmalloc.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/gperftools/tcmalloc.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,9 +215,11 @@ check_include_file("grp.h" HAVE_GRP_H) # for heapchecker_unittest
 check_include_file("pwd.h" HAVE_PWD_H) # for heapchecker_unittest
 check_include_file("sys/resource.h" HAVE_SYS_RESOURCE_H) # for memalign_unittest.cc
 check_include_file("sys/cdefs.h" HAVE_SYS_CDEFS_H) # Where glibc defines __THROW
-check_include_file("ucontext.h" HAVE_UCONTEXT_H)
+
 check_include_file("sys/ucontext.h" HAVE_SYS_UCONTEXT_H)
-check_include_file("cygwin/signal.h" HAVE_CYGWIN_SIGNAL_H)
+check_include_file("ucontext.h" HAVE_UCONTEXT_H)
+check_include_file("cygwin/signal.h" HAVE_CYGWIN_SIGNAL_H) # ucontext on cywgin
+check_include_file("asm/ptrace.h" HAVE_ASM_PTRACE_H) # get ptrace macros, e.g. PT_NIP
 
 check_include_file("unistd.h" HAVE_UNISTD_H)
 # We also need <ucontext.h>/<sys/ucontext.h>, but we get those from

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,12 @@ check_c_source_compiles("#include <stdlib.h>
                          int main() { return 0; }"
         HAVE___ATTRIBUTE__)
 
+check_c_source_compiles("#include <stdlib.h>
+                        void foo(void) __attribute__((aligned(128)));
+                        void foo(void) { exit(1); }
+                        int main() { return 0; }"
+        HAVE___ATTRIBUTE__ALIGNED_FN) 
+
 set(CMAKE_EXTRA_INCLUDE_FILES "malloc.h")
 check_type_size("struct mallinfo" STRUCT_MALLINFO LANGUAGE CXX)
 check_type_size("struct mallinfo2" STRUCT_MALLINFO2 LANGUAGE CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,11 @@ option(gperftools_enable_libunwind
 set(enable_backtrace ${gperftools_enable_stacktrace_via_backtrace})
 set(enable_libunwind ${gperftools_enable_libunwind})
 
+option(gperftools_enable_libgcc_unwinder_by_default
+       "Prefer libgcc's _Unwind_Backtrace as default stacktrace capturing method"
+       OFF)
+set(PREFER_LIBGCC_UNWINDER ${gperftools_enable_libgcc_unwinder_by_default})
+
 set(gperftools_tcmalloc_pagesize ${default_tcmalloc_pagesize}
   CACHE STRING "Set the tcmalloc internal page size")
 set(allowed_page_sizes LIST "4;8;16;32;64;128;256")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,13 @@ option(gperftools_enable_large_alloc_report
       OFF)
 set(ENABLE_LARGE_ALLOC_REPORT ${gperftools_enable_large_alloc_report})
 
+# Enable aggressive decommit by default
+option(gperftools_enable_aggressive_decommit_by_default
+      "Enable aggressive decommit by default"
+      OFF)
+set(ENABLE_AGGRESSIVE_DECOMMIT_BY_DEFAULT ${gperftools_enable_aggressive_decommit_by_default})
+
+
 configure_file(cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h @ONLY)
 configure_file(cmake/tcmalloc.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/gperftools/tcmalloc.h

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -230,6 +230,9 @@
 #endif
 #endif
 
+/* if libgcc stacktrace method should be default */
+#cmakedefine PREFER_LIBGCC_UNWINDER
+
 /* Mark the systems where we know it's bad if pthreads runs too
    early before main (before threads are initialized, presumably).  */
 #ifdef __FreeBSD__


### PR DESCRIPTION
Added build options that were present in autotools but missing in a cmake based configuration.

- aggressive decommit
- large allocation report
- libgcc unwinder preference
- finding `asm/ptrace.h`
- finding `HAVE___ATTRIBUTE__ALIGNED_FN`

Closes #1420