### PR TITLE
feat: make profile buffer size adjustable through env variable

### DIFF
--- a/docs/heapprofile.html
+++ b/docs/heapprofile.html
@@ -158,6 +158,15 @@ environment variables.</p>
   </td>
 </tr>
 
+<tr valign=top>
+  <td><code>HEAP_PROFILE_BUFFER_SIZE</code></td>
+  <td>default: 1048576 (1 Mb)</td>
+  <td>Size of the buffer for heap profiling data (i.e., maximum size of the profile file).
+      Allocation samples beyond this limit will get stripped off. Applications with large
+      number of (de)allocations may need to increase this size to get complete, unstripped data.
+  </td>
+</tr>
+
 </table>
 
 <H2>Checking for Leaks</H2>

--- a/src/heap-profiler.cc
+++ b/src/heap-profiler.cc
@@ -120,6 +120,11 @@ DEFINE_bool(only_mmap_profile,
             EnvToBool("HEAP_PROFILE_ONLY_MMAP", false),
             "If heap-profiling is on, only profile mmap, mremap, and sbrk; "
             "do not profile malloc/new/etc");
+DEFINE_int32(profile_buffer_size,
+             EnvToInt64("HEAP_PROFILE_BUFFER_SIZE", 1 << 20 /*1MB*/),
+             "Size of buffer for heap profiling data. Applications with "
+             "large number of (de)allocations may need more than 1 MB "
+             "to avoid stripping off excess profiling data.");
 
 
 //----------------------------------------------------------------------
@@ -148,7 +153,7 @@ static void ProfilerFree(void* p) {
 }
 
 // We use buffers of this size in DoGetHeapProfile.
-static const int kProfileBufferSize = 1 << 20;
+static const int kProfileBufferSize = FLAGS_profile_buffer_size;
 
 // This is a last-ditch buffer we use in DumpProfileLocked in case we
 // can't allocate more memory from ProfilerMalloc.  We expect this


### PR DESCRIPTION
The profile buffer size has until now been hard-coded to 1 MB. This led to a lot of lost data in our application profiling. We need at least 20 MB buffer size for our use case in order to get complete, trustworthy allocation data.

We have to patch gperftools in our build environment for that. But this is not a preferred solution. The preferred solution is that gperftools has this size configurable by clients at run-time. We guess more clients, not just us, may benefit from this possibility.

This PR adds a new `HEAP_PROFILE_BUFFER_SIZE` env variable for that purpose.

Fixes #1450 