### PR TITLE
Set NOMINMAX in config.h.in to unblock builds with more recent versio…

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -7,6 +7,10 @@
 #define GOOGLE_PERFTOOLS_WINDOWS_CONFIG_H_
 #endif
 
+#if defined(_WIN32) && !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #ifndef GOOGLE_PERFTOOLS_WINDOWS_CONFIG_H_
 #define GOOGLE_PERFTOOLS_WINDOWS_CONFIG_H_
 /* used by tcmalloc.h */


### PR DESCRIPTION
I noticed MSVC CMake builds are broken with a more recent copy of the Windows SDK.

Quick and easy fix - set NOMINMAX in config.h.in to unblock builds with more recent versions of Windows SDK.

