### PR TITLE
fix compile error with gcc 7.5

### DIFF
--- a/src/static_vars.h
+++ b/src/static_vars.h
@@ -39,6 +39,7 @@
 #include "config.h"
 
 #include <atomic>
+#include <cstddef>
 
 #include "base/basictypes.h"
 #include "base/spinlock.h"


### PR DESCRIPTION
In file included from ~/gperftools/src/span.cc:41:0: ~/gperftools/src/static_vars.h:125:37: error: ‘byte’ in namespace ‘std’ does not name a type
     alignas(alignof(PageHeap)) std::byte memory[sizeof(PageHeap)];
                                     ^~~~
~/gperftools/src/static_vars.h: In static member function ‘static tcmalloc::PageHeap* tcmalloc::Static::pageheap()’: ~/gperftools/src/static_vars.h:76:80: error: ‘struct tcmalloc::Static::<unnamed>’ has no member named ‘memory’
   static PageHeap* pageheap() { return reinterpret_cast<PageHeap *>(&pageheap_.memory); }
                                                                                ^~~~~~