### PR TITLE
ISO C++17 does not allow 'register' storage class specifier

### DIFF
--- a/src/tests/heap-checker_unittest.cc
+++ b/src/tests/heap-checker_unittest.cc
@@ -853,7 +853,7 @@ static void* HeapBusyThreadBody(void* a) {
 #elif defined(__x86_64__) && defined(__GNUC__)
   register int** ptr asm("r15");
 #else
-  register int** ptr;
+  int** ptr;
 #endif
   ptr = NULL;
   typedef std::set<int> Set;


### PR DESCRIPTION
Variables in the `heap-checker_unittest` use the `register` storage class. This breaks builds that target C++17 and up.