### PR TITLE
Introduce env to force lower bound on per-thread cache bytes

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -96,7 +96,7 @@ static const size_t kDefaultOverallThreadCacheSize = 8u * kMaxThreadCacheSize;
 #endif
 
 // Lower bound on the per-thread cache sizes
-static const size_t kMinThreadCacheSize = kMaxSize * 2;
+static size_t kMinThreadCacheSize = kMaxSize * 2;
 
 // The number of bytes one ThreadCache will steal from another when
 // the first ThreadCache is forced to Scavenge(), delaying the

--- a/src/thread_cache.cc
+++ b/src/thread_cache.cc
@@ -61,6 +61,12 @@ using std::max;
 //              "for the cache to go over this bound in certain circumstances. "
 //              "Maximum value of this flag is capped to 1 GB.");
 
+DEFINE_int64(tcmalloc_force_lower_bound_per_thread_cache_bytes,
+             EnvToInt64("TCMALLOC_FORCE_LOWER_BOUND_PER_THREAD_CACHE_BYTES",
+                        0),
+             "If set greater than 0, forces given lower bound on the amount "
+             "of bytes allocated to per-thread cache. Default lower bound is "
+             "set to 512KB.");
 
 namespace tcmalloc {
 
@@ -78,6 +84,11 @@ ThreadCache::ThreadCache() {
   ASSERT(Static::pageheap_lock()->IsHeld());
 
   size_ = 0;
+
+  if (FLAGS_tcmalloc_force_lower_bound_per_thread_cache_bytes > 0) {
+    kMinThreadCacheSize =
+      FLAGS_tcmalloc_force_lower_bound_per_thread_cache_bytes;
+  }
 
   max_size_ = 0;
   IncreaseCacheLimitLocked();


### PR DESCRIPTION
Added an env to control the lower bound on the value of per-thread cache which is set as 512kB (seems to be on the higher side) in the current model.

Related issues: [1511](https://github.com/gperftools/gperftools/issues/1511)