### PR TITLE
generic_fp stacktrace: aarch64 frame pointer may be 8 byte aligned

### DIFF
--- a/src/stacktrace_generic_fp-inl.h
+++ b/src/stacktrace_generic_fp-inl.h
@@ -177,8 +177,12 @@ int capture(void **result, int max_depth, int skip_count,
   // older gcc's (circa gcc 6 or so) did something that looks right,
   // but not recent ones).
   constexpr uintptr_t kAlignment = 4;
+#elif defined(__aarch64__)
+  // aarch64 ABI does not specify the frame pointer location, so we can only
+  // know it's 8 byte aligned (as the register size)
+  constexpr uintptr_t kAlignment = 8;
 #else
-  // This is simplistic yet. Here we're targeting x86, aarch64 and
+  // This is simplistic yet. Here we're targeting x86 and
   // riscv. They all have 16 bytes stack alignment (even 32 bit
   // riscv). This can be made more elaborate as we consider more
   // architectures.


### PR DESCRIPTION
The aarch64 ABI does not specify the alignment of the frame pointer, it only specify the alignment of the stack frame.

From [the ABI doc](https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#the-frame-pointer):

> SP mod 16 = 0. The stack must be quad-word aligned.
> ...
> The location of the frame record within a stack frame is not specified.

Clang in particularly would generate such code. [Example](https://godbolt.org/z/nan8crMGf):

![2024-05-24_19-38](https://github.com/gperftools/gperftools/assets/1308450/6fe5d398-7ff4-43b6-8be4-51c1923bf28d)
