### PR TITLE
Fixed an error in ppref

### DIFF
--- a/src/pprof
+++ b/src/pprof
@@ -70,6 +70,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use Getopt::Long;
 use Cwd;
 use POSIX;
@@ -4535,7 +4536,7 @@ sub ParseLibraries {
       $finish = HexExtend($2);
       $offset = $zero_offset;
       $lib = $3;
-    } elsif (($l =~ /^($h)-($h)\s+..x.\s+($h)\s+\S+:\S+\s+\d+\s+(\S+)$/i) && ($4 eq $prog)) {
+    } elsif (($l =~ /^($h)-($h)\s+..x.\s+($h)\s+\S+:\S+\s+\d+\s+(\S+)$/i) && (basename($4) eq basename($prog))) {
       # PIEs and address space randomization do not play well with our
       # default assumption that main executable is at lowest
       # addresses. So we're detecting main executable in


### PR DESCRIPTION
When searching for symbols in the analyzed program, if the program is analyzed on another machine, the paths to the program executable file specified in the pprof call argument and the path specified in the analysis results file may differ. Therefore, the condition of comparing these paths does not work. It is necessary to compare not the paths, but the names of executable files.
