### PR TITLE
stacktrace_libunwind: Use unw_backtrace to compute backtrace faster

### DIFF
--- a/src/stacktrace.cc
+++ b/src/stacktrace.cc
@@ -277,13 +277,15 @@ static GetStackImplementation *get_stack_impl;
 #if 0
 // This is for the benefit of code analysis tools that may have
 // trouble with the computed #include above.
-# include "stacktrace_libunwind-inl.h"
 # include "stacktrace_generic-inl.h"
+# include "stacktrace_libgcc-inl.h"
+# include "stacktrace_libunwind-inl.h"
 # include "stacktrace_generic_fp-inl.h"
 # include "stacktrace_powerpc-linux-inl.h"
-# include "stacktrace_win32-inl.h"
+# include "stacktrace_powerpc-darwin-inl.h"
 # include "stacktrace_arm-inl.h"
 # include "stacktrace_instrument-inl.h"
+# include "stacktrace_win32-inl.h"
 #endif
 
 static void init_default_stack_impl_inner(void);

--- a/src/stacktrace_libunwind-inl.h
+++ b/src/stacktrace_libunwind-inl.h
@@ -81,18 +81,45 @@ static __thread int recursive ATTR_INITIAL_EXEC;
 //   int skip_count: how many stack pointers to skip before storing in result
 //   void* ucp: a ucontext_t* (GetStack{Trace,Frames}WithContext only)
 static int GET_STACK_TRACE_OR_FRAMES {
-  void *ip;
   int n = 0;
+  if (recursive) {
+    return 0;
+  }
+  ++recursive;
+
+#if (!IS_WITH_CONTEXT && !IS_STACK_FRAMES)
+  // GetStackTrace(): Use unw_backtrace() to get the backtrace more quickly.
+
+  // From malloc_hook.cc, the maximum backtrace size that's requested is
+  // <= 32 + 6 + 3 + 1 + max_depth. We add another 2 for GetStackTrace()'s
+  // skip_count.
+  constexpr size_t kMaxBacktraceSize = 32 + 6 + 3 + 1 + 32 + 2;
+  static __thread void *libunwind_backtrace_result[kMaxBacktraceSize];
+
+  skip_count += 2;
+  if (PREDICT_FALSE(skip_count + max_depth > kMaxBacktraceSize)) {
+    fprintf(stderr,
+            "error: exceeded max backtrace size of %lu. max depth = %d, skip "
+            "count = %d.\n",
+            kMaxBacktraceSize, max_depth, skip_count);
+    exit(1);
+  }
+  n = unw_backtrace(libunwind_backtrace_result, max_depth + skip_count);
+  n -= skip_count;
+  if (PREDICT_FALSE(n <= 0)) {
+    n = 0;
+    goto out;
+  }
+
+  std::copy(libunwind_backtrace_result + skip_count,
+            libunwind_backtrace_result + skip_count + n, result);
+#else
+  void *ip;
   unw_cursor_t cursor;
   unw_context_t uc;
 #if IS_STACK_FRAMES
   unw_word_t sp = 0, next_sp = 0;
 #endif
-
-  if (recursive) {
-    return 0;
-  }
-  ++recursive;
 
 #if (IS_WITH_CONTEXT && defined(BASE_STACKTRACE_UNW_CONTEXT_IS_UCONTEXT))
   if (ucp) {
@@ -147,6 +174,8 @@ static int GET_STACK_TRACE_OR_FRAMES {
     sizes[n - 1] = next_sp - sp;
 #endif
   }
+#endif
+
 out:
   --recursive;
   return n;


### PR DESCRIPTION
Previously, stacktrace_libunwind used unw cursors to compute the backtrace, which is slow. This PR updates stacktrace_libunwind's `GetStackTrace()` function to compute the backtrace using `unw_backtrace`, which is substantially faster.

The main benefit of this change is that malloc profiling becomes substantially faster. I have seen > 5x profiling performance improvements with this change.

I was also able to reproduce @acmorrow's benchmark results from #1277 on my machine. The current libunwind's `GetStackTrace()` implementation performance is as follows:

```
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
BM_GetStackTrace/1          3832 ns         3828 ns       182886 items_per_second=261.232k/s
BM_GetStackTrace/8          7705 ns         7692 ns        95400 items_per_second=130.008k/s
BM_GetStackTrace/64        31017 ns        31003 ns        22564 items_per_second=32.2546k/s
BM_GetStackTrace/512      184911 ns       184846 ns         3789 items_per_second=5.4099k/s
BM_GetStackTrace/4096    1356384 ns      1353508 ns          491 items_per_second=738.821/s
BM_GetStackTrace/8192    2578422 ns      2564196 ns          273 items_per_second=389.986/s
```

With this PR, the performance improves substantially:

```
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
BM_GetStackTrace/1           102 ns          102 ns      6913378 items_per_second=9.84186M/s
BM_GetStackTrace/8           166 ns          166 ns      4218120 items_per_second=6.02384M/s
BM_GetStackTrace/64          517 ns          517 ns      1355825 items_per_second=1.93412M/s
BM_GetStackTrace/512        3252 ns         3251 ns       216073 items_per_second=307.559k/s
BM_GetStackTrace/4096      25256 ns        25194 ns        27830 items_per_second=39.6917k/s
BM_GetStackTrace/8192      50328 ns        50238 ns        13935 items_per_second=19.9051k/s
```

I have tested this change with `make check` and `make stacktrace_unittest && ./stacktrace_unittest`.

I would greatly appreciate any feedback regarding this PR. Thank you!

Closes #1277