### PR TITLE
fix compiler error when NO_TCMALLOC_SAMPLES is defined

### DIFF
--- a/src/malloc_backtrace.cc
+++ b/src/malloc_backtrace.cc
@@ -41,7 +41,7 @@ extern "C" {
 }
 
 namespace tcmalloc {
-
+#ifndef NO_TCMALLOC_SAMPLES
 // GrabBacktrace is the API to use when capturing backtrace for
 // various tcmalloc features. It has optional emergency malloc
 // integration for occasional case where stacktrace capturing method
@@ -84,5 +84,5 @@ int GrabBacktrace(void** result, int max_depth, int skip_count) {
   // Prevent tail calling WithStacktraceScope above
   return *const_cast<volatile int*>(&args.result_depth);
 }
-
+#endif
 }  // namespace tcmalloc


### PR DESCRIPTION
the error is:
src/malloc_backtrace.cc:51:5: error: redefinition of 'int tcmalloc::GrabBacktrace(void**, int, int)'
   51 | int GrabBacktrace(void** result, int max_depth, int skip_count) {
      |     ^~~~~~~~~~~~~
In file included from src/malloc_backtrace.cc:34:
src/malloc_backtrace.h:43:12: note: 'int tcmalloc::GrabBacktrace(void**, int, int)' previously defined here
   43 | inline int GrabBacktrace(void** result, int max_depth, int skip_count) { return 0; }