### PR TITLE
introduce 2 new env vars to config ThreadCache initial state

### DIFF
--- a/src/thread_cache.h
+++ b/src/thread_cache.h
@@ -262,6 +262,7 @@ class ThreadCache {
   void IncreaseCacheLimit();
   // Same as above but requires Static::pageheap_lock() is held.
   void IncreaseCacheLimitLocked();
+  void SetInitialLimitLocked();
 
   // Linked list of heap objects.  Protected by Static::pageheap_lock.
   static ThreadCache* thread_heaps_;
@@ -279,6 +280,8 @@ class ThreadCache {
   // Overall thread cache size.  Protected by Static::pageheap_lock.
   static size_t overall_thread_cache_size_;
 
+  static size_t initial_thread_cache_size_;
+
   // Global per-thread cache size.  Writes are protected by
   // Static::pageheap_lock.  Reads are done without any locking, which should be
   // fine as long as size_t can be written atomically and we don't place
@@ -288,6 +291,8 @@ class ThreadCache {
   // Represents overall_thread_cache_size_ minus the sum of max_size_
   // across all ThreadCaches.  Protected by Static::pageheap_lock.
   static ssize_t unclaimed_cache_space_;
+
+  static bool use_batch_size_from_start_;
 
   // This class is laid out with the most frequently used fields
   // first so that hot elements are placed on the same cache line.


### PR DESCRIPTION
new variables:
TCMALLOC_BATCH_SIZE_FROM_START:
Set the thread cache max length size to num_objects_to_move(cl) if defined

The default behavior is to set the initial max_length to 1 and increment it by 1 each time objects are fetched. Once the max_lenght reaches num_objects_to_move(cl), the max_length is now incremented by num_objects_to_move(cl) as it has been demonstrated that this particular size is in high demand.

This is done that way to minimize memory wasting. Bigger blocks are allocated only once the need for this size class has been confirmed.

If the possibility of wasting some memory is acceptable, enabling this option to eliminate the ramp-up period will:
- reduce number of accesses to the central heap
- Preserve the data locality of the objects in opposition to have the address space distributed evenly across all the caches if a particular size is requested by all threads.

This second point is not only valid when the client code access the allocated memory but also when the memory is deallocated when it is put back into a free list.

TCMALLOC_INITIAL_THREAD_CACHE_BYTES:
Set the initial cache max_size_ value.

The default behavior is to initialize the value to kStealAmount (64Kb) and increment it by kStealAmount each time a Scavenge() is triggered when a cache size reach the max_size value. This approach is the best to efficiently distribute the heap across all the caches but this imply several accesses to the central heap.

If you know the number of created threads by a process this env variable allows you to manually distribute the heap across all the threads and eliminates several central heap accesses needed to reach their stable size.

results:
--------
The after results have been obtained with the following setting:
LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so TCMALLOC_RELEASE_RATE=0 TCMALLOC_TRANSFER_NUM_OBJ=1024 TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=100000000 TCMALLOC_INITIAL_THREAD_CACHE_BYTES=2000000 TCMALLOC_BATCH_SIZE_FROM_START=1

This appears to be an experiment that turns out to be inconclusive. With some parameters, the performance is better,
with some others the performance is worse.

It is NOT, by far, a clear-cut winner. I am not convinced myself that this should be integrated in the project.
I mostly share this experiment to stimulate and influence other experiments in that area to improve the project...
maybe with a different approach or angle, some tweaking of the idea, someone could make it work better.

![mops_vs_threads_init_cache_size](https://github.com/user-attachments/assets/d1a72f2f-6dee-494c-b9b6-294c8e84e962)
![mops_vs_size_init_cache_size](https://github.com/user-attachments/assets/8322d5b7-7ee3-41bc-8250-2c55bf68d880)

