### PR TITLE
Fix gcc 10 compilation error

### DIFF
--- a/src/tests/sampling_test.cc
+++ b/src/tests/sampling_test.cc
@@ -67,7 +67,7 @@ static std::string NaiveShellQuote(std::string_view arg) {
 
 extern "C" ATTRIBUTE_NOINLINE
 void* AllocateAllocate() {
-  auto local_noopt = [] (void* ptr) ATTRIBUTE_NOINLINE -> void* {
+  auto local_noopt = [] (void* ptr) ATTRIBUTE_NOINLINE {
     return noopt(ptr);
   };
   return local_noopt(malloc(10000));


### PR DESCRIPTION
Apparently, gcc 10 doesn't support trailing return types for lambdas with an attribute.

```
src/tests/sampling_test.cc: In lambda function:
src/tests/sampling_test.cc:70:56: error: expected '{' before '->' token
   70 |   auto local_noopt = [] (void* ptr) ATTRIBUTE_NOINLINE -> void* {
      |                                                        ^~
src/tests/sampling_test.cc: In function 'void* AllocateAllocate()':
src/tests/sampling_test.cc:70:56: error: base operand of '->' has non-pointer type 'AllocateAllocate()::<lambda(void*)>'
src/tests/sampling_test.cc:70:59: error: expected unqualified-id before 'void'
   70 |   auto local_noopt = [] (void* ptr) ATTRIBUTE_NOINLINE -> void* {
      |                                                           ^~~~
```

Remove the trailing return type as it is deduced from the `noopt` call anyway.

gcc 10.2.1 is used as the system compiler in Debian 11 Bullseye.