### PR TITLE
Fix #1611: Add correct hyperlink for heap profiler document

### DIFF
--- a/docs/tcmalloc.adoc
+++ b/docs/tcmalloc.adoc
@@ -99,7 +99,7 @@ using LD_PRELOAD:
    % LD_PRELOAD="/usr/lib/libtcmalloc.so"
 ....
 
-TCMalloc includes a link:heapprofile.html[heap profiler] as well.
+TCMalloc includes a link:heapprofile.adoc[heap profiler] as well.
 
 If you'd rather link in a version of TCMalloc that does not include
 the heap profiler (perhaps to reduce binary size for a static binary),


### PR DESCRIPTION
- Add heapprofile.adoc hyperlink to tcmalloc.adoc instead of deprecated heapprofile.html
- Unit tests run is clean