### PR TITLE
Fix #1613: Update all the hyperlinks to point to adoc files instead of HTML

### DIFF
--- a/docs/cpuprofile-fileformat.adoc
+++ b/docs/cpuprofile-fileformat.adoc
@@ -5,7 +5,7 @@
 This file documents the binary data file format produced by the
 gperftools CPU Profiler. It is one of "legacy" formats supported by
 the pprof tool. For information about using the CPU Profiler, see
-link:cpuprofile.html[its user guide].
+link:cpuprofile.adoc[its user guide].
 
 The profiler source code, which generates files using this format, is at
 `src/profiler.cc`.

--- a/docs/cpuprofile.adoc
+++ b/docs/cpuprofile.adoc
@@ -9,7 +9,7 @@ running the code, and analyzing the output.
 
 On the off-chance that you should need to understand it, the CPU
 profiler data file format is documented separately,
-link:cpuprofile-fileformat.html[here].
+link:cpuprofile-fileformat.adoc[here].
 
 == Linking in the Library
 

--- a/docs/heapprofile.adoc
+++ b/docs/heapprofile.adoc
@@ -133,7 +133,7 @@ written to the program's working directory.
 
 The profile output can be viewed by passing it to the
 `pprof` tool -- the same tool that's used to analyze <A
-link:cpuprofile.html[CPU profiles].
+link:cpuprofile.adoc[CPU profiles].
 
 Here are some examples.  These examples assume the binary is named
 `gfs_master`, and a sequence of heap profile files can be

--- a/docs/pprof_integration.adoc
+++ b/docs/pprof_integration.adoc
@@ -34,14 +34,14 @@ API is in `gperftools/profiler.h`. You can invoke
 libprofiler automagically profile the full run of your program by setting
 `CPUPROFILE` environment variable.
 
-See link:cpuprofile.html[documentation of CPU profiler] for full
+See link:cpuprofile.adoc[documentation of CPU profiler] for full
 details.
 
 A general description of how statistical sampling profilers work can be
 found in this nice blog post: https://research.swtch.com/pprof.
 
 We produce a "legacy" CPU profile format. The format is described
-here: link:cpuprofile-fileformat.html[].
+here: link:cpuprofile-fileformat.adoc[].
 
 === Heap sample
 
@@ -75,7 +75,7 @@ https://github.com/google/tcmalloc/blob/master/docs/sampling.md.
 
 Go has similar feature called heap profiling. Go's heap profiles
 combine information about in-use memory and all the allocations ever
-made. It is similar to gperftools' link:heapprofile.html[heap profiler] but works
+made. It is similar to gperftools' link:heapprofile.adoc[heap profiler] but works
 via sampling, so it is low overhead and runs by default. You can read
 about it here: https://pkg.go.dev/runtime/pprof. Approximately every
 512k bytes (value of runtime.MemProfileRate) of memory allocated, Go's
@@ -100,7 +100,7 @@ off from libtcmalloc_minimal.
 
 === Heap Profiler
 
-See link:heapprofile.html[Heap Profiler documentation]. Note that the
+See link:heapprofile.adoc[Heap Profiler documentation]. Note that the
 heap profiler intercepts every allocation and deallocation call, so it
 runs with a much higher overhead than normal malloc and is not
 suitable for production.


### PR DESCRIPTION
- Correct the hyperlinks to adoc files
- Unit tests run is clean