### PR TITLE
Adding headers for WORDSIZE (musl), ASM and fix ucontext for musl

### DIFF
--- a/src/base/elf_mem_image.cc
+++ b/src/base/elf_mem_image.cc
@@ -87,7 +87,7 @@ class ElfClass<64> {
   static int ElfType(const ElfW(Sym) * symbol) { return ELF64_ST_TYPE(symbol->st_info); }
 };
 
-typedef ElfClass<__WORDSIZE> CurrentElfClass;
+typedef ElfClass<sizeof(void*) * 8> CurrentElfClass;
 
 // Extract an element from one of the ELF tables, cast it to desired type.
 // This is just a simple arithmetic and a glorified cast.

--- a/src/stacktrace_powerpc-linux-inl.h
+++ b/src/stacktrace_powerpc-linux-inl.h
@@ -48,6 +48,9 @@
 #include <gperftools/stacktrace.h>
 #include <base/vdso_support.h>
 
+#ifdef HAVE_ASM_PTRACE_H
+#include <asm/ptrace.h>
+#endif
 #if HAVE_SYS_UCONTEXT_H
 #include <sys/ucontext.h>
 #elif HAVE_UCONTEXT_H

--- a/src/stacktrace_powerpc-linux-inl.h
+++ b/src/stacktrace_powerpc-linux-inl.h
@@ -198,7 +198,11 @@ static int GET_STACK_TRACE_OR_FRAMES {
           ucontext_t uc;
           // We don't care about the rest, since IP value is at 'uc' field.A
         }* sigframe = reinterpret_cast<rt_signal_frame_32*>(current);
+#if defined(__GLIBC__)
         result[n] = (void*)sigframe->uc.uc_mcontext.uc_regs->gregs[PT_NIP];
+#else
+        result[n] = (void*)sigframe->uc.uc_mcontext.gregs[PT_NIP];
+#endif
       }
 #endif
 


### PR DESCRIPTION
1. The first commit is heavily inspired by gcc: https://gcc.gnu.org/cgit/gcc/commit/?id=6a4e9934545c112eef5eb7248636baa96cbfd2c0 to fix ``uc_regs (glibc) x gregs (e.g. musl)``

2. The second commit  defines ``PT_NIP`` by adding asm/ptrace header

3. The third commit defines __WORDSIZE while building for musl and ppc by adding sys/reg

Fixes: https://github.com/gperftools/gperftools/issues/1602 and many thanks to @Cynerd, who helped me with this one.