### PR TITLE
update BUILD.bazel and MODULE.bazel to load rules_cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /addressmap_unittest
 /addressmap_unittest.exe
 /autom4te.cache/
+/bazel-*
 /benchmark/.deps
 /benchmark/.dirstamp
 /binary_trees
@@ -95,6 +96,7 @@
 /min_per_thread_cache_size_test
 /min_per_thread_cache_size_test.exe
 /missing
+/MODULE.bazel.lock
 /packed_cache_test
 /packed_cache_test.exe
 /page_heap_test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,8 @@
 # NOTE: as of this writing Bazel support is highly experimental. It is
 # also not entirely complete. It lacks most tests, for example.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 config_setting(
     name = "is_gcc",
     flag_values = {"@bazel_tools//tools/cpp:compiler": "gcc"},

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,5 @@
 module(name = "gperftools", version = "2.17.2", compatibility_level = 2)
 
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)


### PR DESCRIPTION
#### Description

Update BUILD.bazel and MODULE.bazel to load rules_cc

This allows to be compatible with Bazel 9 constraints