### PR TITLE
Add BCR workflow to publish gperftools on tag creation

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,80 @@
+# Bazel Central Registry (BCR) Publishing
+
+This directory contains template files for automated publishing to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+
+## Overview
+
+The workflow automatically publishes new versions of gperftools to the BCR when a new tag is created following the pattern `gperftools-X.Y.Z`.
+
+## Setup
+
+### 1. Create a BCR Fork
+
+The maintainer needs to fork the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry) repository to their personal or organization account.
+
+### 2. Create a Personal Access Token (PAT)
+
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+2. Click "Generate new token (classic)"
+3. Give it a descriptive name (e.g., "BCR Publish Token")
+4. Select the following scopes:
+   - `repo` (full control of private repositories)
+   - `workflow` (update GitHub Action workflows)
+5. Generate the token and copy it immediately (it won't be shown again)
+
+### 3. Add the Token as a Repository Secret
+
+1. Go to the gperftools repository settings
+2. Navigate to Secrets and variables → Actions
+3. Click "New repository secret"
+4. Name: `BCR_PUBLISH_TOKEN`
+5. Value: Paste the PAT you created
+6. Click "Add secret"
+
+## Usage
+
+### Automatic Publishing
+
+When you create a new release tag (e.g., `gperftools-2.17.3`), the workflow will automatically:
+
+1. Trigger on the tag push
+2. Generate the BCR entry using the template files in this directory
+3. Push the entry to your BCR fork
+4. Open a draft pull request to the official BCR
+
+### Manual Publishing
+
+If you need to republish or troubleshoot, you can manually trigger the workflow:
+
+1. Go to Actions → Publish to BCR
+2. Click "Run workflow"
+3. Enter the tag name (e.g., `gperftools-2.17.3`)
+4. Click "Run workflow"
+
+## Template Files
+
+- **metadata.template.json**: Contains repository information and maintainers
+- **source.template.json**: Defines the source archive URL pattern and structure
+- **presubmit.yml**: Specifies the build and test targets for BCR validation
+
+These files are used to generate the actual BCR entry when a new version is published.
+
+## Troubleshooting
+
+### Pull Request Not Created
+
+- Verify that `BCR_PUBLISH_TOKEN` is set correctly in repository secrets
+- Check that the PAT has `repo` and `workflow` permissions
+- Ensure the BCR fork exists and is accessible
+
+### Build Failures in BCR
+
+- Review the presubmit.yml targets to ensure they are correct
+- Check that the MODULE.bazel file is up to date
+- Verify the source archive URL pattern in source.template.json
+
+## More Information
+
+- [Publish to BCR Documentation](https://github.com/bazel-contrib/publish-to-bcr)
+- [BCR Contribution Guidelines](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md)
+- [Bzlmod User Guide](https://bazel.build/docs/bzlmod)

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/gperftools/gperftools",
+  "maintainers": [
+    {
+      "github": "alk",
+      "github_user_id": 14850,
+      "name": "Aliaksiej Kandracienka (aka Aliaksei Kandratsenka)"
+    }
+  ],
+  "repository": [
+    "github:gperftools/gperftools"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@gperftools//:cpu_profiler'
+    - '@gperftools//:tcmalloc'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "gperftools-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.tar.gz"
+}

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -1,0 +1,34 @@
+name: Publish to BCR
+
+on:
+  # Trigger on tag creation
+  push:
+    tags:
+      - 'gperftools-*'
+  # Allow manual dispatch for troubleshooting
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to publish (e.g., gperftools-2.17.3)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v6
+    with:
+      tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+      # The official Bazel Central Registry
+      registry: bazelbuild/bazel-central-registry
+      # Tag prefix to strip for version calculation
+      tag_prefix: "gperftools-"
+      # Enable attestations for release artifacts
+      attest: false
+      # Open PR as draft (recommended for BCR auto-approval workflow)
+      draft: true
+    permissions:
+      contents: write
+    secrets:
+      # This token must be created as a Classic PAT with 'repo' and 'workflow' permissions
+      # and stored as a repository secret named BCR_PUBLISH_TOKEN
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
#### Description

This workflow will help publish to BCR after a tag is published.

Based on https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/gperftools