### PR TITLE
Fix link order for Mingw when building shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,11 +426,6 @@ target_sources(common PRIVATE
 
 set(SYSTEM_ALLOC_CC src/windows/system-alloc.cc)
 set(TCMALLOC_CC src/windows/patch_functions.cc)
-
-# patch_function uses -lpsapi and spinlock bits use -synchronization
-# and -lshlwapi
-link_libraries(psapi synchronization shlwapi)
-
 endif()
 
 if(BUILD_TESTING)
@@ -519,6 +514,9 @@ endif()
 target_compile_definitions(tcmalloc_minimal PRIVATE NO_TCMALLOC_SAMPLES)
 target_link_options(tcmalloc_minimal INTERFACE ${TCMALLOC_FLAGS})
 target_link_libraries(tcmalloc_minimal PRIVATE common)
+if(MINGW OR MSVC)
+  target_link_libraries(tcmalloc_minimal PUBLIC psapi synchronization shlwapi)
+endif()
 
 if(BUILD_TESTING)
   add_executable(tcmalloc_minimal_unittest


### PR DESCRIPTION
Greetings! 

As we started to update the gperftools project on [Conan Center](https://conan.io/center/recipes/gperftools?version=2.17.2) to support Windows build by using the current CMakeLists.txt in the repository (I know, CMake support is incomplete and is best-effort only), we validated version 2.17.2 on Windows, with MSVC 194, Clang-CL and Mingw. You can follow our effort via https://github.com/conan-io/conan-center-index/pull/30380. 

Mostly of builds were sweet, but Mingw, when built as shared library, we found the following error when linking:

```
[33/33] C:\WINDOWS\system32\cmd.exe /C "cd . && C:\Users\uilia\.conan2\p\mingwbdcc29e5a5afb\p\bin\g++.exe -m64 -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -fsized-deallocation -O3 -DNDEBUG  -m64 -shared -o libtcmalloc_minimal.dll -Wl,--out-implib,libtcmalloc_minimal.dll.a -Wl,--major-image-version,0,--minor-image-version,0 CMakeFiles/tcmalloc_minimal.dir/src/windows/patch_functions.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/common.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/internal_logging.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/windows/system-alloc.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/memfs_malloc.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/safe_strerror.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/central_freelist.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/page_heap.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/sampler.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/span.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/stack_trace_table.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/static_vars.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/thread_cache.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/thread_cache_ptr.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/malloc_hook.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/malloc_extension.cc.obj  -lpsapi  -lsynchronization  -lshlwapi  libcommon.a  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
FAILED: libtcmalloc_minimal.dll libtcmalloc_minimal.dll.a 
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\Users\uilia\.conan2\p\mingwbdcc29e5a5afb\p\bin\g++.exe -m64 -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare -fsized-deallocation -O3 -DNDEBUG  -m64 -shared -o libtcmalloc_minimal.dll -Wl,--out-implib,libtcmalloc_minimal.dll.a -Wl,--major-image-version,0,--minor-image-version,0 CMakeFiles/tcmalloc_minimal.dir/src/windows/patch_functions.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/common.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/internal_logging.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/windows/system-alloc.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/memfs_malloc.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/safe_strerror.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/central_freelist.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/page_heap.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/sampler.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/span.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/stack_trace_table.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/static_vars.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/thread_cache.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/thread_cache_ptr.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/malloc_hook.cc.obj CMakeFiles/tcmalloc_minimal.dir/src/malloc_extension.cc.obj  -lpsapi  -lsynchronization  -lshlwapi  libcommon.a  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
C:/Users/uilia/.conan2/p/mingwbdcc29e5a5afb/p/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libcommon.a(spinlock_internal.cc.obj):spinlock_internal.cc:(.text+0x6e): undefined reference to `WaitOnAddress'
C:/Users/uilia/.conan2/p/mingwbdcc29e5a5afb/p/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libcommon.a(spinlock_internal.cc.obj):spinlock_internal.cc:(.text+0x95): undefined reference to `WakeByAddressAll'
C:/Users/uilia/.conan2/p/mingwbdcc29e5a5afb/p/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: libcommon.a(spinlock_internal.cc.obj):spinlock_internal.cc:(.text+0xa1): undefined reference to `WakeByAddressSingle'

collect2.exe: error: ld returned 1 exit status
```

You can see the full build log here: [gperftools-2.17.2-windows-amd64-mingw-release-shared-option.log](https://github.com/user-attachments/files/29643128/gperftools-2.17.2-windows-amd64-mingw-release-shared-option.log)

The build for static library is fine, only shared is breaking. Also, we know `WaitOnAddress` is part of WINAPI [Synchronization](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitonaddress).

----

As the CMakeLists.txt uses the global `link_libraries(psapi synchronization shlwapi)`, the Mingw `ld` resolves archives in a single left-to-right pass, so by the time it encounters `libcommon.a` (which contains `spinlock_internal.cc.obj` with the unresolved references), it has already moved past `synchronization`. The result is a link failure when building a DLL, where all symbols must be fully resolved at link time.

This does not affect MSVC builds because `link.exe` performs multiple resolution passes and is insensitive to input ordering. And for static build, the consumer will link those system libraries, so we actually do not link then when building libcommon.a or tcmalloc_minimal.

This PR replaces the global `link_libraries()` with the scoped and safer `target_link_libraries()` call to `tcmalloc_minimal`. Using `PUBLIC` ensures the system libraries are placed correctly after `common` in the DLL link command (fixing the MinGW ordering issue). As it's PUBLIC, it also propagated to static consumers that link against `tcmalloc_minimal` and transitively pull in `common`.

After applying this patch, I can build version 2.17.2 with Mingw + Shared without errors: [gperftools-2.17.2-windows-amd64-mingw-release-shared-patched.log](https://github.com/user-attachments/files/29643227/gperftools-2.17.2-windows-amd64-mingw-release-shared-patched.log)

I know version 2.17.2 is not the latest, but this part of the code did not change since this version. 

Feel free to comment about this proposal. Regards! 
