### PR TITLE
Don't pick up vendored googletest from bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,2 @@
+# Don't pick up vendored gtest, we use it from MODULE.bazel
+vendor/googletest


### PR DESCRIPTION
In bazel, we use the googletest from MODULE.bazel, so tell bazel to not recurse into the vendored directory.

This allows to `bazel build ...` without issue.