### PR TITLE
Fix link of backtrace-alloc.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,8 @@
 # NOTE: as of this writing Bazel support is highly experimental. It is
 # also not entirely complete. It lacks most tests, for example.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 config_setting(
     name = "is_clang",
@@ -292,12 +292,14 @@ cc_library(
     deps = [
         ":all_headers",
         ":libbacktrace",
+        ":low_level_alloc",
     ],
 )
 
 cc_library(
     name = "low_level_alloc",
     srcs = ["src/base/low_level_alloc.cc"],
+    hdrs = ["src/base/low_level_alloc.h"],
     copts = CXXFLAGS,
     includes = [
         "generic-config",


### PR DESCRIPTION
The backtrace alloc showed link issues of the form

```
bazel-out/k8-opt/bin/_objs/symbolize/backtrace-alloc.o:backtrace-alloc.cc:function tcmalloc::BTPagesAllocator::~BTPagesAllocator():(.text._ZN8tcmalloc16BTPagesAllocatorD2Ev+0xb): error: undefined reference to 'tcmalloc::LowLevelAlloc::PagesAllocator::~PagesAllocator()'
bazel-out/k8-opt/bin/_objs/symbolize/backtrace-alloc.o:backtrace-alloc.cc:function tcmalloc::BTPagesAllocator::~BTPagesAllocator():(.text._ZN8tcmalloc16BTPagesAllocatorD0Ev+0x17): error: undefined reference to 'tcmalloc::LowLevelAlloc::PagesAllocator::~PagesAllocator()'
bazel-out/k8-opt/bin/_objs/symbolize/backtrace-alloc.o:backtrace-alloc.cc:function tcmalloc::BTPagesAllocator::AllocateAsHeader(unsigned long):(.text._ZN8tcmalloc16BTPagesAllocator16AllocateAsHeaderEm+0xd): error: undefined reference to 'tcmalloc::LowLevelAlloc::GetDefaultPagesAllocator()'
bazel-out/k8-opt/bin/_objs/symbolize/backtrace-alloc.o:backtrace-alloc.cc:function tcmalloc::BTPagesAllocator::AllocateAsHeader(unsigned long):(.text._ZN8tcmalloc16BTPagesAllocator16AllocateAsHeaderEm+0x69): error: undefined reference to 'tcmalloc::LowLevelAlloc::GetDefaultPagesAllocator()'
...
```

This was due to not depending on a library that provided these symbols.

Part of the problem is that the `:all_headers` target collects all the headers but no actual implementations.
So this probably should be detangled more, but this PR at least fixes the immediate build issue.