### PR TITLE
Add `:gtest` dependencies to tests using the headers.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,8 @@
 # NOTE: as of this writing Bazel support is highly experimental. It is
 # also not entirely complete. It lacks most tests, for example.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 config_setting(
     name = "is_clang",
@@ -555,6 +555,7 @@ cc_test(
         ":all_headers",
         ":single_stepper",
         ":tcmalloc_minimal",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )
@@ -570,6 +571,7 @@ cc_test(
         ":all_headers",
         ":single_stepper",
         ":tcmalloc_minimal_debug",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )
@@ -585,6 +587,7 @@ cc_test(
         ":all_headers",
         ":single_stepper",
         ":tcmalloc",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )
@@ -600,6 +603,7 @@ cc_test(
         ":all_headers",
         ":single_stepper",
         ":tcmalloc_debug",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )
@@ -614,6 +618,7 @@ cc_test(
     deps = [
         ":all_headers",
         ":tcmalloc_debug",
+        "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
Thee tests linked against `:gtest_main` that only indirectly provided these headers; but in the spirit of `dwyu` (Depend on What You Use), we should also directly depend on the gtest lib.